### PR TITLE
added feature "stop users enumeration"

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-misc-options-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-misc-options-menu.php
@@ -10,6 +10,7 @@ class AIOWPSecurity_Misc_Options_Menu extends AIOWPSecurity_Admin_Menu
     var $menu_tabs_handler = array(
         'tab1' => 'render_tab1',
         'tab2' => 'render_tab2',
+        'tab3' => 'render_tab3',
         );
 
     function __construct() 
@@ -168,5 +169,57 @@ class AIOWPSecurity_Misc_Options_Menu extends AIOWPSecurity_Admin_Menu
         </div></div>
         <?php
     }
+    
+    function render_tab3()
+    {
+        global $aio_wp_security;
+        $maint_msg = '';
+        if(isset($_POST['aiowpsec_save_users_enumeration']))
+        {
+            $nonce=$_REQUEST['_wpnonce'];
+            if (!wp_verify_nonce($nonce, 'aiowpsec-users-enumeration'))
+            {
+                $aio_wp_security->debug_logger->log_debug("Nonce check failed on prevent users enumeration feature settings save!",4);
+                die("Nonce check failed on prevent users enumeration frame feature settings save!");
+            }
+
+            //Save settings
+            $aio_wp_security->configs->set_value('aiowps_prevent_users_enumeration',isset($_POST["aiowps_prevent_users_enumeration"])?'1':'');
+            $aio_wp_security->configs->save_config();
+
+            $this->show_msg_updated(__('Users Enumeration Prevention feature settings saved!', 'all-in-one-wp-security-and-firewall'));
+
+        }
+        ?>
+        <div class="postbox">
+        <h3 class="hndle"><label for="title"><?php _e('Prevent Users Enumeration', 'all-in-one-wp-security-and-firewall'); ?></label></h3>
+        <div class="inside">
+        <form action="" method="POST">
+        <?php wp_nonce_field('aiowpsec-users-enumeration'); ?>
+        <div class="aio_blue_box">
+            <?php
+            echo '<p>'.__('This feature allows you to prevent external users/bots from fetching the user info with urls like "/?author=1".', 'all-in-one-wp-security-and-firewall').'</p>';
+            echo '<p>'.__('When enabled, this feature will print "Forbidden" rather than the user informations.', 'all-in-one-wp-security-and-firewall').'</p>';
+            ?>
+        </div>
+        <table class="form-table">
+            <tr valign="top">
+                <th scope="row"><?php _e('Disable Users Enumeration', 'all-in-one-wp-security-and-firewall')?>:</th>
+                <td>
+                <input name="aiowps_prevent_users_enumeration" type="checkbox"<?php if($aio_wp_security->configs->get_value('aiowps_prevent_users_enumeration')=='1') echo ' checked="checked"'; ?> value="1"/>
+                <span class="description"><?php _e('Check this if you want to stop users enumeration.', 'all-in-one-wp-security-and-firewall'); ?></span>
+                </td>
+            </tr>
+
+        </table>
+
+        <div class="submit">
+            <input type="submit" class="button-primary" name="aiowpsec_save_users_enumeration" value="<?php _e('Save Settings'); ?>" />
+        </div>
+        </form>
+        </div></div>
+        <?php
+    }
+
     
 } //end class

--- a/all-in-one-wp-security/classes/wp-security-configure-settings.php
+++ b/all-in-one-wp-security/classes/wp-security-configure-settings.php
@@ -124,6 +124,8 @@ class AIOWPSecurity_Configure_Settings
         $aio_wp_security->configs->set_value('aiowps_copy_protection','');//Checkbox
         //Prevent others from dislaying your site in iframe
         $aio_wp_security->configs->set_value('aiowps_prevent_site_display_inside_frame','');//Checkbox
+       //Prevent users enumeration
+        $aio_wp_security->configs->set_value('aiowps_prevent_users_enumeration','');//Checkbox
         
                 
         //TODO - keep adding default options for any fields that require it
@@ -250,6 +252,8 @@ class AIOWPSecurity_Configure_Settings
         $aio_wp_security->configs->add_value('aiowps_copy_protection','');//Checkbox
         //Prevent others from dislaying your site in iframe
         $aio_wp_security->configs->add_value('aiowps_prevent_site_display_inside_frame','');//Checkbox
+        //Prevent users enumeration
+        $aio_wp_security->configs->set_value('aiowps_prevent_users_enumeration','');//Checkbox
 
         
         //TODO - keep adding default options for any fields that require it

--- a/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
+++ b/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
@@ -44,6 +44,11 @@ class AIOWPSecurity_General_Init_Tasks
             }
         }
         
+        //stop users enumeration
+        if( $aio_wp_security->configs->get_value('aiowps_prevent_users_enumeration') == 1) {
+            include_once(AIO_WP_SECURITY_PATH.'/other-includes/wp-security-stop-users-enumeration.php');
+        }
+        
         //For user unlock request feature
         if(isset($_POST['aiowps_unlock_request']) || isset($_POST['aiowps_wp_submit_unlock_request'])){
             nocache_headers();            

--- a/all-in-one-wp-security/other-includes/wp-security-stop-users-enumeration.php
+++ b/all-in-one-wp-security/other-includes/wp-security-stop-users-enumeration.php
@@ -1,0 +1,44 @@
+<?php
+/*
+Merged by Davide Giunchi, from plugin "Stop User Enumeration" url "http://locally.uk/wordpress-plugins/stop-user-enumeration/" by "Locally Digital Ltd"
+*/
+
+/*
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+if ( ! is_admin()){
+    if ( ! is_admin()){
+      if(preg_match('/(wp-comments-post)/', $_SERVER['REQUEST_URI']) === 0 ) {
+         if (!empty($_POST['author'])) {
+            wp_die('forbidden');
+         }
+      }
+
+    if(preg_match('/author=([0-9]*)/', $_SERVER['QUERY_STRING']) === 1)
+    wp_die('forbidden');
+
+    add_filter('redirect_canonical','ll_detect_enumeration', 10,2);
+        }
+}
+
+add_filter('redirect_canonical','ll_detect_enumeration', 10,2);
+function ll_detect_enumeration ($redirect_url, $requested_url) {
+if (preg_match('/\?author(%00[0%]*)?=([0-9]*)(\/*)/', $requested_url)===1  | isset($_POST['author']) ) {
+     wp_die('forbidden');
+   } else {
+     return $redirect_url;
+   }
+}


### PR DESCRIPTION
Feature merged to aiowps from plugin https://wordpress.org/plugins/stop-user-enumeration/ on gpl license.
If you enable this feature, it will disable wordpress users enumeration with urls like "/?author=1", by displaying a "forbidden" error message.
You can configure it from  the menù aiowpsec_misc, on tab3.
Discussion on: https://wordpress.org/support/topic/patch-new-feature-proposal-enumerate-users?replies=3