### PR TITLE
Fix for firewall rules that caused issues on subdirectory install

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
@@ -859,9 +859,9 @@ class AIOWPSecurity_Utility_Htaccess
         global $aio_wp_security;
         $rules = '';
         if ($aio_wp_security->configs->get_value('aiowps_enable_spambot_blocking') == '1') {
-            $url_string = AIOWPSecurity_Utility_Htaccess::return_regularized_url(AIOWPSEC_WP_URL);
+            $url_string = AIOWPSecurity_Utility_Htaccess::return_regularized_url(AIOWPSEC_WP_HOME_URL);
             if ($url_string == FALSE) {
-                $url_string = AIOWPSEC_WP_URL;
+                $url_string = AIOWPSEC_WP_HOME_URL;
             }
             $rules .= AIOWPSecurity_Utility_Htaccess::$block_spambots_marker_start . PHP_EOL; //Add feature marker start
             $rules .= '<IfModule mod_rewrite.c>
@@ -885,9 +885,9 @@ class AIOWPSecurity_Utility_Htaccess
         global $aio_wp_security;
         $rules = '';
         if ($aio_wp_security->configs->get_value('aiowps_prevent_hotlinking') == '1') {
-            $url_string = AIOWPSecurity_Utility_Htaccess::return_regularized_url(AIOWPSEC_WP_URL);
+            $url_string = AIOWPSecurity_Utility_Htaccess::return_regularized_url(AIOWPSEC_WP_HOME_URL);
             if ($url_string == FALSE) {
-                $url_string = AIOWPSEC_WP_URL;
+                $url_string = AIOWPSEC_WP_HOME_URL;
             }
             $rules .= AIOWPSecurity_Utility_Htaccess::$prevent_image_hotlinks_marker_start . PHP_EOL; //Add feature marker start
             $rules .= '<IfModule mod_rewrite.c>

--- a/all-in-one-wp-security/wp-security-core.php
+++ b/all-in-one-wp-security/wp-security-core.php
@@ -51,7 +51,9 @@ class AIO_WP_Security{
     {
         define('AIO_WP_SECURITY_VERSION', $this->version);
         define('AIO_WP_SECURITY_DB_VERSION', $this->db_version);
-        define('AIOWPSEC_WP_URL', site_url());
+        define('AIOWPSEC_WP_HOME_URL', home_url());
+        define('AIOWPSEC_WP_SITE_URL', site_url());
+        define('AIOWPSEC_WP_URL', AIOWPSEC_WP_SITE_URL); // for backwards compatibility
         define('AIO_WP_SECURITY_URL', $this->plugin_url());
         define('AIO_WP_SECURITY_PATH', $this->plugin_path());
         define('AIO_WP_SECURITY_BACKUPS_DIR_NAME', 'aiowps_backups');


### PR DESCRIPTION
Fix for Prevent Image Hotlinks and Block Spam Bots firewall rules that have been broken on WP sites installed in [subdirectory](https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory) as reported on support forums:
- https://wordpress.org/support/topic/problems-with-subdirectory-install
- https://wordpress.org/support/topic/images-disappear-after-setting-firewall-prevent-hotlinks
- https://wordpress.org/support/topic/problem-with-anti-hotlink-with-wp-subdirectory-install