### PR TITLE
Fix #13: Add 6G Firewall 2016 as a configurable option.

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-firewall-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-firewall-menu.php
@@ -27,7 +27,7 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
         $this->menu_tabs = array(
         'tab1' => __('Basic Firewall Rules', 'all-in-one-wp-security-and-firewall'),
         'tab2' => __('Additional Firewall Rules', 'all-in-one-wp-security-and-firewall'),
-        'tab3' => __('5G Blacklist Firewall Rules', 'all-in-one-wp-security-and-firewall'),
+        'tab3' => __('6G Blacklist Firewall Rules', 'all-in-one-wp-security-and-firewall'),
         'tab4' => __('Internet Bots', 'all-in-one-wp-security-and-firewall'),
         'tab5' => __('Prevent Hotlinks', 'all-in-one-wp-security-and-firewall'),
         'tab6' => __('404 Detection', 'all-in-one-wp-security-and-firewall'),
@@ -493,14 +493,14 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
     
     function render_tab3()
     {
-        global $aio_wp_security;
-        if(isset($_POST['aiowps_apply_5g_firewall_settings']))//Do form submission tasks
+        global $aio_wp_security, $aiowps_feature_mgr;
+        if(isset($_POST['aiowps_apply_5g_6g_firewall_settings']))//Do form submission tasks
         {
             $nonce=$_REQUEST['_wpnonce'];
-            if (!wp_verify_nonce($nonce, 'aiowpsec-enable-5g-firewall-nonce'))
+            if (!wp_verify_nonce($nonce, 'aiowpsec-enable-5g-6g-firewall-nonce'))
             {
-                $aio_wp_security->debug_logger->log_debug("Nonce check failed on enable 5G firewall settings!",4);
-                die("Nonce check failed on enable 5G firewall settings!");
+                $aio_wp_security->debug_logger->log_debug("Nonce check failed on enable 5G/6G firewall settings!",4);
+                die("Nonce check failed on enable 5G/6G firewall settings!");
             }
 
             //Save settings
@@ -512,6 +512,14 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
             {
                 $aio_wp_security->configs->set_value('aiowps_enable_5g_firewall','');
             }
+            if(isset($_POST['aiowps_enable_6g_firewall']))
+            {
+                $aio_wp_security->configs->set_value('aiowps_enable_6g_firewall','1');
+            }
+            else
+            {
+                $aio_wp_security->configs->set_value('aiowps_enable_6g_firewall','');
+            }
 
             //Commit the config settings
             $aio_wp_security->configs->save_config();
@@ -521,7 +529,9 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
 
             if ($res)
             {
-                $this->show_msg_updated(__('You have successfully saved the 5G Firewall Protection configuration', 'all-in-one-wp-security-and-firewall'));
+                $this->show_msg_updated(__('You have successfully saved the 5G/6G Firewall Protection configuration', 'all-in-one-wp-security-and-firewall'));
+                // Recalculate points after the feature status/options have been altered
+                $aiowps_feature_mgr->check_feature_status_and_recalculate_points();
             }
             else if($res == -1)
             {
@@ -534,28 +544,47 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
         <div class="aio_blue_box">
             <?php
             $backup_tab_link = '<a href="admin.php?page='.AIOWPSEC_SETTINGS_MENU_SLUG.'&tab=tab2" target="_blank">backup</a>';
-            $info_msg = '<p>'.sprintf( __('This feature allows you to activate the 5G  firewall security protection rules designed and produced by %s.', 'all-in-one-wp-security-and-firewall'), '<a href="http://perishablepress.com/5g-blacklist-2013/" target="_blank">Perishable Press</a>').'</p>';
-            $info_msg .= '<p>'.__('The 5G Blacklist is a simple, flexible blacklist that helps reduce the number of malicious URL requests that hit your website.', 'all-in-one-wp-security-and-firewall').'</p>';
-            $info_msg .= '<p>'.__('The added advantage of applying the 5G firewall to your site is that it has been tested and confirmed by the people at PerishablePress.com to be an optimal and least disruptive set of .htaccess security rules for general WP sites running on an Apache server or similar.', 'all-in-one-wp-security-and-firewall').'</p>';
-            $info_msg .= '<p>'.sprintf( __('Therefore the 5G firewall rules should not have any impact on your site\'s general functionality but if you wish you can take a %s of your .htaccess file before proceeding.', 'all-in-one-wp-security-and-firewall'), $backup_tab_link).'</p>';
+            $info_msg = '<p>'.sprintf( __('This feature allows you to activate the %s (or legacy %s) firewall security protection rules designed and produced by %s.', 'all-in-one-wp-security-and-firewall'), '<a href="http://perishablepress.com/6g/" target="_blank">6G</a>', '<a href="http://perishablepress.com/5g-blacklist-2013/" target="_blank">5G</a>', '<a href="http://perishablepress.com/" target="_blank">Perishable Press</a>').'</p>';
+			$info_msg .= '<p>'.__('The 6G Blacklist is updated and improved version of 5G Blacklist. If you have 5G Blacklist active, you might consider activating 6G Blacklist instead.', 'all-in-one-wp-security-and-firewall').'</p>';
+            $info_msg .= '<p>'.__('The 6G Blacklist is a simple, flexible blacklist that helps reduce the number of malicious URL requests that hit your website.', 'all-in-one-wp-security-and-firewall').'</p>';
+            $info_msg .= '<p>'.__('The added advantage of applying the 6G firewall to your site is that it has been tested and confirmed by the people at PerishablePress.com to be an optimal and least disruptive set of .htaccess security rules for general WP sites running on an Apache server or similar.', 'all-in-one-wp-security-and-firewall').'</p>';
+            $info_msg .= '<p>'.sprintf( __('Therefore the 6G firewall rules should not have any impact on your site\'s general functionality but if you wish you can take a %s of your .htaccess file before proceeding.', 'all-in-one-wp-security-and-firewall'), $backup_tab_link).'</p>';
             echo $info_msg;
             ?>
         </div>
 
         <div class="postbox">
-        <h3 class="hndle"><label for="title"><?php _e('5G Blacklist/Firewall Settings', 'all-in-one-wp-security-and-firewall'); ?></label></h3>
+        <h3 class="hndle"><label for="title"><?php _e('6G Blacklist/Firewall Settings', 'all-in-one-wp-security-and-firewall'); ?></label></h3>
         <div class="inside">
         <?php
         //Display security info badge
         global $aiowps_feature_mgr;
-        $aiowps_feature_mgr->output_feature_details_badge("firewall-enable-5g-blacklist");
+        $aiowps_feature_mgr->output_feature_details_badge("firewall-enable-5g-6g-blacklist");
         ?>
             
         <form action="" method="POST">
-        <?php wp_nonce_field('aiowpsec-enable-5g-firewall-nonce'); ?>            
+        <?php wp_nonce_field('aiowpsec-enable-5g-6g-firewall-nonce'); ?>
         <table class="form-table">
             <tr valign="top">
-                <th scope="row"><?php _e('Enable 5G Firewall Protection', 'all-in-one-wp-security-and-firewall')?>:</th>
+                <th scope="row"><?php _e('Enable 6G Firewall Protection', 'all-in-one-wp-security-and-firewall')?>:</th>
+                <td>
+                <input name="aiowps_enable_6g_firewall" type="checkbox"<?php if($aio_wp_security->configs->get_value('aiowps_enable_6g_firewall')=='1') echo ' checked="checked"'; ?> value="1"/>
+                <span class="description"><?php _e('Check this if you want to apply the 6G Blacklist firewall protection from perishablepress.com to your site.', 'all-in-one-wp-security-and-firewall'); ?></span>
+                <span class="aiowps_more_info_anchor"><span class="aiowps_more_info_toggle_char">+</span><span class="aiowps_more_info_toggle_text"><?php _e('More Info', 'all-in-one-wp-security-and-firewall'); ?></span></span>
+                <div class="aiowps_more_info_body">
+                        <?php
+                        echo '<p class="description">'.__('This setting will implement the 6G security firewall protection mechanisms on your site which include the following things:', 'all-in-one-wp-security-and-firewall').'</p>';
+                        echo '<p class="description">'.__('1) Block forbidden characters commonly used in exploitative attacks.', 'all-in-one-wp-security-and-firewall').'</p>';
+                        echo '<p class="description">'.__('2) Block malicious encoded URL characters such as the ".css(" string.', 'all-in-one-wp-security-and-firewall').'</p>';
+                        echo '<p class="description">'.__('3) Guard against the common patterns and specific exploits in the root portion of targeted URLs.', 'all-in-one-wp-security-and-firewall').'</p>';
+                        echo '<p class="description">'.__('4) Stop attackers from manipulating query strings by disallowing illicit characters.', 'all-in-one-wp-security-and-firewall').'</p>';
+                        echo '<p class="description">'.__('....and much more.', 'all-in-one-wp-security-and-firewall').'</p>';
+                        ?>
+                </div>
+                </td>
+            </tr>
+            <tr valign="top">
+                <th scope="row"><?php _e('Enable legacy 5G Firewall Protection', 'all-in-one-wp-security-and-firewall')?>:</th>
                 <td>
                 <input name="aiowps_enable_5g_firewall" type="checkbox"<?php if($aio_wp_security->configs->get_value('aiowps_enable_5g_firewall')=='1') echo ' checked="checked"'; ?> value="1"/>
                 <span class="description"><?php _e('Check this if you want to apply the 5G Blacklist firewall protection from perishablepress.com to your site.', 'all-in-one-wp-security-and-firewall'); ?></span>
@@ -573,7 +602,7 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
                 </td>
             </tr>            
         </table>
-        <input type="submit" name="aiowps_apply_5g_firewall_settings" value="<?php _e('Save 5G Firewall Settings', 'all-in-one-wp-security-and-firewall')?>" class="button-primary" />
+        <input type="submit" name="aiowps_apply_5g_6g_firewall_settings" value="<?php _e('Save 5G/6G Firewall Settings', 'all-in-one-wp-security-and-firewall')?>" class="button-primary" />
         </form>
         </div></div>
         <?php

--- a/all-in-one-wp-security/classes/grade-system/wp-security-feature-item-manager.php
+++ b/all-in-one-wp-security/classes/grade-system/wp-security-feature-item-manager.php
@@ -94,7 +94,7 @@ class AIOWPSecurity_Feature_Item_Manager
         $this->feature_items[] = new AIOWPSecurity_Feature_Item("firewall-forbid-proxy-comments", __("Forbid Proxy Comments", "all-in-one-wp-security-and-firewall"), $this->feature_point_2, $this->sec_level_advanced);
         $this->feature_items[] = new AIOWPSecurity_Feature_Item("firewall-deny-bad-queries", __("Deny Bad Queries", "all-in-one-wp-security-and-firewall"), $this->feature_point_3, $this->sec_level_advanced);
         $this->feature_items[] = new AIOWPSecurity_Feature_Item("firewall-advanced-character-string-filter", __("Advanced Character String Filter", "all-in-one-wp-security-and-firewall"), $this->feature_point_3, $this->sec_level_advanced);
-        $this->feature_items[] = new AIOWPSecurity_Feature_Item("firewall-enable-5g-blacklist", __("5G Blacklist", "all-in-one-wp-security-and-firewall"), $this->feature_point_4, $this->sec_level_advanced);
+        $this->feature_items[] = new AIOWPSecurity_Feature_Item("firewall-enable-5g-6g-blacklist", __("5G/6G Blacklist", "all-in-one-wp-security-and-firewall"), $this->feature_point_4, $this->sec_level_advanced);
         $this->feature_items[] = new AIOWPSecurity_Feature_Item("firewall-block-fake-googlebots", __("Block Fake Googlebots", "all-in-one-wp-security-and-firewall"), $this->feature_point_1, $this->sec_level_advanced);
         //SPAM Prevention
         $this->feature_items[] = new AIOWPSecurity_Feature_Item("block-spambots", __("Block Spambots", "all-in-one-wp-security-and-firewall"), $this->feature_point_2, $this->sec_level_basic);
@@ -286,9 +286,9 @@ class AIOWPSecurity_Feature_Item_Manager
             {
                 $this->check_advanced_char_string_filter_firewall_feature($item);
             }
-            if($item->feature_id == "firewall-enable-5g-blacklist")
+            if($item->feature_id == "firewall-enable-5g-6g-blacklist")
             {
-                $this->check_enable_5G_blacklist_firewall_feature($item);
+                $this->check_enable_5G_6G_blacklist_firewall_feature($item);
             }
             if($item->feature_id == "firewall-block-fake-googlebots")
             {
@@ -701,10 +701,13 @@ class AIOWPSecurity_Feature_Item_Manager
         }
     }
 
-    function check_enable_5G_blacklist_firewall_feature($item)
+    function check_enable_5G_6G_blacklist_firewall_feature($item)
     {
         global $aio_wp_security;
         if ($aio_wp_security->configs->get_value('aiowps_enable_5g_firewall') == '1') {
+            $item->set_feature_status($this->feature_active);
+        }
+        else if ($aio_wp_security->configs->get_value('aiowps_enable_6g_firewall') == '1') {
             $item->set_feature_status($this->feature_active);
         }
         else

--- a/all-in-one-wp-security/classes/wp-security-configure-settings.php
+++ b/all-in-one-wp-security/classes/wp-security-configure-settings.php
@@ -80,6 +80,7 @@ class AIOWPSecurity_Configure_Settings
         $aio_wp_security->configs->set_value('aiowps_deny_bad_query_strings','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_advanced_char_string_filter','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_enable_5g_firewall','');//Checkbox
+        $aio_wp_security->configs->set_value('aiowps_enable_6g_firewall','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_enable_custom_rules','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_custom_rules','');
         
@@ -210,6 +211,7 @@ class AIOWPSecurity_Configure_Settings
         $aio_wp_security->configs->add_value('aiowps_deny_bad_query_strings','');//Checkbox
         $aio_wp_security->configs->add_value('aiowps_advanced_char_string_filter','');//Checkbox
         $aio_wp_security->configs->add_value('aiowps_enable_5g_firewall','');//Checkbox
+        $aio_wp_security->configs->add_value('aiowps_enable_6g_firewall','');//Checkbox
         $aio_wp_security->configs->add_value('aiowps_enable_custom_rules','');//Checkbox
         $aio_wp_security->configs->add_value('aiowps_custom_rules','');
 
@@ -295,6 +297,7 @@ class AIOWPSecurity_Configure_Settings
         $aio_wp_security->configs->set_value('aiowps_deny_bad_query_strings','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_advanced_char_string_filter','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_enable_5g_firewall','');//Checkbox
+        $aio_wp_security->configs->set_value('aiowps_enable_6g_firewall','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_enable_brute_force_attack_prevention','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_enable_custom_rules','');//Checkbox
         $aio_wp_security->configs->set_value('aiowps_custom_rules','');

--- a/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
@@ -43,6 +43,9 @@ class AIOWPSecurity_Utility_Htaccess
     public static $five_g_blacklist_marker_start = '#AIOWPS_FIVE_G_BLACKLIST_START';
     public static $five_g_blacklist_marker_end = '#AIOWPS_FIVE_G_BLACKLIST_END';
 
+    public static $six_g_blacklist_marker_start = '#AIOWPS_SIX_G_BLACKLIST_START';
+    public static $six_g_blacklist_marker_end = '#AIOWPS_SIX_G_BLACKLIST_END';
+
     public static $block_spambots_marker_start = '#AIOWPS_BLOCK_SPAMBOTS_START';
     public static $block_spambots_marker_end = '#AIOWPS_BLOCK_SPAMBOTS_END';
 
@@ -185,6 +188,7 @@ class AIOWPSecurity_Utility_Htaccess
         $rules .= AIOWPSecurity_Utility_Htaccess::getrules_forbid_proxy_comment_posting();
         $rules .= AIOWPSecurity_Utility_Htaccess::getrules_deny_bad_query_strings();
         $rules .= AIOWPSecurity_Utility_Htaccess::getrules_advanced_character_string_filter();
+        $rules .= AIOWPSecurity_Utility_Htaccess::getrules_6g_blacklist();
         $rules .= AIOWPSecurity_Utility_Htaccess::getrules_5g_blacklist();
         $rules .= AIOWPSecurity_Utility_Htaccess::getrules_enable_brute_force_prevention();
         $rules .= AIOWPSecurity_Utility_Htaccess::getrules_block_spambots();
@@ -845,6 +849,81 @@ class AIOWPSecurity_Utility_Htaccess
                                 RewriteRule .* - [F]
                         </IfModule>' . PHP_EOL;
             $rules .= AIOWPSecurity_Utility_Htaccess::$five_g_blacklist_marker_end . PHP_EOL; //Add feature marker end
+        }
+
+        return $rules;
+    }
+
+    /*
+     * This function contains the rules for the 6G blacklist produced by Jeff Starr:
+	 * https://perishablepress.com/6g/
+     */
+    static function getrules_6g_blacklist()
+    {
+        global $aio_wp_security;
+        $rules = '';
+        if ($aio_wp_security->configs->get_value('aiowps_enable_6g_firewall') == '1') {
+            $rules .= AIOWPSecurity_Utility_Htaccess::$six_g_blacklist_marker_start . PHP_EOL; //Add feature marker start
+
+            $rules .= '# 6G BLACKLIST/FIREWALL (2016)
+                        # @ https://perishablepress.com/6g/
+
+                        # 6G:[QUERY STRINGS]
+                        <IfModule mod_rewrite.c>
+                                RewriteEngine On
+                                RewriteCond %{QUERY_STRING} (eval\() [NC,OR]
+                                RewriteCond %{QUERY_STRING} (127\.0\.0\.1) [NC,OR]
+                                RewriteCond %{QUERY_STRING} ([a-z0-9]{2000}) [NC,OR]
+                                RewriteCond %{QUERY_STRING} (javascript:)(.*)(;) [NC,OR]
+                                RewriteCond %{QUERY_STRING} (base64_encode)(.*)(\() [NC,OR]
+                                RewriteCond %{QUERY_STRING} (GLOBALS|REQUEST)(=|\[|%) [NC,OR]
+                                RewriteCond %{QUERY_STRING} (<|%3C)(.*)script(.*)(>|%3) [NC,OR]
+                                RewriteCond %{QUERY_STRING} (\\|\.\.\.|\.\./|~|`|<|>|\|) [NC,OR]
+                                RewriteCond %{QUERY_STRING} (boot\.ini|etc/passwd|self/environ) [NC,OR]
+                                RewriteCond %{QUERY_STRING} (thumbs?(_editor|open)?|tim(thumb)?)\.php [NC,OR]
+                                RewriteCond %{QUERY_STRING} (\'|\")(.*)(drop|insert|md5|select|union) [NC]
+                                RewriteRule .* - [F]
+                        </IfModule>
+
+                        # 6G:[REQUEST METHOD]
+                        <ifModule mod_rewrite.c>
+                                RewriteCond %{REQUEST_METHOD} ^(connect|debug|delete|move|put|trace|track) [NC]
+                                RewriteRule .* - [F]
+                        </IfModule>
+
+                        # 6G:[REFERRERS]
+                        <IfModule mod_rewrite.c>
+                                RewriteCond %{HTTP_REFERER} ([a-z0-9]{2000}) [NC,OR]
+                                RewriteCond %{HTTP_REFERER} (semalt.com|todaperfeita) [NC]
+                                RewriteRule .* - [F]
+                        </IfModule>
+
+                        # 6G:[REQUEST STRINGS]
+                        <IfModule mod_alias.c>
+                                RedirectMatch 403 (?i)([a-z0-9]{2000})
+                                RedirectMatch 403 (?i)(https?|ftp|php):/
+                                RedirectMatch 403 (?i)(base64_encode)(.*)(\()
+                                RedirectMatch 403 (?i)(=\\\'|=\\%27|/\\\'/?)\.
+                                RedirectMatch 403 (?i)/(\$(\&)?|\*|\"|\.|,|&|&amp;?)/?$
+                                RedirectMatch 403 (?i)(\{0\}|\(/\(|\.\.\.|\+\+\+|\\\"\\\")
+                                RedirectMatch 403 (?i)(~|`|<|>|:|;|,|%|\\|\s|\{|\}|\[|\]|\|)
+                                RedirectMatch 403 (?i)/(=|\$&|_mm|cgi-|etc/passwd|muieblack)
+                                RedirectMatch 403 (?i)(&pws=0|_vti_|\(null\)|\{\$itemURL\}|echo(.*)kae|etc/passwd|eval\(|self/environ)
+                                RedirectMatch 403 (?i)\.(aspx?|bash|bak?|cfg|cgi|dll|exe|git|hg|ini|jsp|log|mdb|out|sql|svn|swp|tar|rar|rdf)$
+                                RedirectMatch 403 (?i)/(^$|(wp-)?config|mobiquo|phpinfo|shell|sqlpatch|thumb|thumb_editor|thumbopen|timthumb|webshell)\.php
+                        </IfModule>
+
+                        # 6G:[USER AGENTS]
+                        <IfModule mod_setenvif.c>
+                                SetEnvIfNoCase User-Agent ([a-z0-9]{2000}) bad_bot
+                                SetEnvIfNoCase User-Agent (archive.org|binlar|casper|checkpriv|choppy|clshttp|cmsworld|diavol|dotbot|extract|feedfinder|flicky|g00g1e|harvest|heritrix|httrack|kmccrew|loader|miner|nikto|nutch|planetwork|postrank|purebot|pycurl|python|seekerspider|siclab|skygrid|sqlmap|sucker|turnit|vikspider|winhttp|xxxyy|youda|zmeu|zune) bad_bot
+                                <limit GET POST PUT>
+                                        Order Allow,Deny
+                                        Allow from all
+                                        Deny from env=bad_bot
+                                </limit>
+                        </IfModule>' . PHP_EOL;
+            $rules .= AIOWPSecurity_Utility_Htaccess::$six_g_blacklist_marker_end . PHP_EOL; //Add feature marker end
         }
 
         return $rules;


### PR DESCRIPTION
This commit adds implementation of [6G Firewall 2016](https://perishablepress.com/6g/) from Jeff Star to the plugin:

6G Firewall is implemented as a standalone feature, therefore **users have to explicitly activate 6G Firewall for the firewall rules to be added to .htaccess file.**

The "5G Blacklist Firewall Rules" tab has a new configuration option to enable 6G Firewall, the legacy 5G Firewall configuration option is retained. Textual information on the tab has been slightly updated to inform users that 6G Firewall is updated version of 5G Firewall and to encourage them to activate 6G Firewall instead of 5G.

There is no new feature item for score calculation for 6G Firewall. Instead, the existing feature item is for 5G Firewall is considered as active, if either 5G or 6G Firewall configuration option is on. In other words, users get no extra points for activating both 5G and 6G Firewall at the same time.

I would appreciate if you review the request and either accept it or let me know how should I improve it. I would really like to have 6G Firewall in the plugin.

Greetings,
Česlav