### PR TITLE
Fix #14: Do not block HTTP requests that contain "tag=" in query string.

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
@@ -644,7 +644,7 @@ class AIOWPSecurity_Utility_Htaccess
             $rules .= AIOWPSecurity_Utility_Htaccess::$deny_bad_query_strings_marker_start . PHP_EOL; //Add feature marker start
             //$rules .= 'RewriteCond %{QUERY_STRING} ../    [NC,OR]' . PHP_EOL;
             //$rules .= 'RewriteCond %{QUERY_STRING} boot.ini [NC,OR]' . PHP_EOL;
-            $rules .= 'RewriteCond %{QUERY_STRING} tag=     [NC,OR]' . PHP_EOL;
+            //$rules .= 'RewriteCond %{QUERY_STRING} tag=     [NC,OR]' . PHP_EOL;
             $rules .= 'RewriteCond %{QUERY_STRING} ftp:     [NC,OR]' . PHP_EOL;
             $rules .= 'RewriteCond %{QUERY_STRING} http:    [NC,OR]' . PHP_EOL;
             $rules .= 'RewriteCond %{QUERY_STRING} https:   [NC,OR]' . PHP_EOL;


### PR DESCRIPTION
Hello,

As I mentioned in issue #14, I consider "`tag=`" rule too harsh to be part of bad query strings and already came across a legitimate back-end operation that has been blocked by it (see the issue for more details).

Please, consider removing it.

Greets,
Česlav