### PR TITLE
Fix issue with firewall custom rules being corrupted

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-firewall-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-firewall-menu.php
@@ -997,8 +997,10 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
             {
                 if (!empty($_POST['aiowps_custom_rules']))
                 {
-                    $custom_rules = $_POST['aiowps_custom_rules'];
-
+                    // Undo magic quotes that are automatically added to `$_GET`,
+                    // `$_POST`, `$_COOKIE`, and `$_SERVER` by WordPress as
+                    // they corrupt any custom rule with backslash in it...
+                    $custom_rules = stripslashes($_POST['aiowps_custom_rules']);
                 }
                 else
                 {


### PR DESCRIPTION
Hi,

this is a straight-forward fix for issue with firewall custom rules [reported here](https://wordpress.org/support/topic/firewallcustom-rules-bug-when-pasting-text-with-escaped-characters).

The cause of this issue is that WordPress since version 3.0 [automatically applies magic quotes](https://core.trac.wordpress.org/browser/branches/4.5/src/wp-settings.php#L282) to all $_GET, $_POST, $_COOKIE and $_SERVER data.

Cheers,
Česlav