### PR TITLE
Fix: Use home URL instead of site URL in lock notification email subject

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-user-login.php
+++ b/all-in-one-wp-security/classes/wp-security-user-login.php
@@ -267,7 +267,7 @@ class AIOWPSecurity_User_Login
         $email_msg = '';
         if ($email_notification_enabled == 1)
         {
-            $subject = '['.get_option('siteurl').'] '. __('Site Lockout Notification','all-in-one-wp-security-and-firewall');
+            $subject = '['.get_option('home').'] '. __('Site Lockout Notification','all-in-one-wp-security-and-firewall');
             $email_msg .= __('A lockdown event has occurred due to too many failed login attempts or invalid username:','all-in-one-wp-security-and-firewall')."\n";
             $email_msg .= __('Username: '.($username?$username:"Unknown"),'all-in-one-wp-security-and-firewall')."\n";
             $email_msg .= __('IP Address: '.$ip,'all-in-one-wp-security-and-firewall')."\n\n";


### PR DESCRIPTION
Hi,

This is a small fix for sites that are installed in subdirectory and thus have site_url different than home_url.

This is how subject of the lock notification email looks now:
_[http://example.com/subdirectory] Site Lockout Notification_

This is how subject of the lock notification email looks after the fix:
_[http://example.com] Site Lockout Notification_

Cheers,
Česlav