### PR TITLE
Tweak: Remove "@" from list of characters blocked by advanced character string filter

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
@@ -679,7 +679,10 @@ class AIOWPSecurity_Utility_Htaccess
     //Redirectmatch 403 convert(
     //RedirectMatch 403 .inc
     //RedirectMatch 403 include.
-
+    //
+    // The "@" sign is often used in filenames of retina-ready images like
+    // "logo@2x.jpg", therefore it has been removed from the list.
+    //RedirectMatch 403 \@
 
     static function getrules_advanced_character_string_filter()
     {
@@ -693,7 +696,6 @@ class AIOWPSecurity_Utility_Htaccess
                         RedirectMatch 403 \:
                         RedirectMatch 403 \;
                         RedirectMatch 403 \=
-                        RedirectMatch 403 \@
                         RedirectMatch 403 \[
                         RedirectMatch 403 \]
                         RedirectMatch 403 \^


### PR DESCRIPTION
Hi,

I would suggest to remove "@" from list of characters blocked by advanced character string filter, because it is often used in retina-ready images (as per [Apple's recommendation](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html#//apple_ref/doc/uid/TP40012302-CH7-SW28)).

A lot of themes and popular [WP Retina 2x](https://wordpress.org/plugins/wp-retina-2x/) plugin use this convention. The change would prevent some hard to debug support requests like [this one](https://wordpress.org/support/topic/related-posts-images-1).

Cheers,
Česlav