### PR TITLE
Fix: display correct (error) message when write_to_htaccess() fails

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-admin-init.php
+++ b/all-in-one-wp-security/admin/wp-security-admin-init.php
@@ -122,7 +122,7 @@ class AIOWPSecurity_Admin_Init
 
                 //Write this new cookie to the .htaccess file
                 $res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
-                if($res == -1){
+                if( !$res ){
                     $aio_wp_security->debug_logger->log_debug("Error writing new test cookie with random suffix to .htaccess file!",4);
                 }
 

--- a/all-in-one-wp-security/admin/wp-security-blacklist-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-blacklist-menu.php
@@ -131,7 +131,7 @@ class AIOWPSecurity_Blacklist_Menu extends AIOWPSecurity_Admin_Menu
                     $this->show_msg_settings_updated();
 
                     $write_result = AIOWPSecurity_Utility_Htaccess::write_to_htaccess(); //now let's write to the .htaccess file
-                    if ($write_result == -1)
+                    if ( !$write_result )
                     {
                         $this->show_msg_error(__('The plugin was unable to write to the .htaccess file. Please edit file manually.','all-in-one-wp-security-and-firewall'));
                         $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_Blacklist_Menu - The plugin was unable to write to the .htaccess file.");

--- a/all-in-one-wp-security/admin/wp-security-brute-force-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-brute-force-menu.php
@@ -130,10 +130,10 @@ class AIOWPSecurity_Brute_Force_Menu extends AIOWPSecurity_Admin_Menu
                 //Recalculate points after the feature status/options have been altered
                 $aiowps_feature_mgr->check_feature_status_and_recalculate_points();
                 $res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess(); //Delete the cookie based directives if that feature is active
-                if ($res){
+                if ($res) {
                     $this->show_msg_settings_updated();
                 }
-                else if($res == -1){
+                else {
                     $this->show_msg_error(__('Could not delete the Cookie-based directives from the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
                 }
             }
@@ -287,12 +287,12 @@ class AIOWPSecurity_Brute_Force_Menu extends AIOWPSecurity_Admin_Menu
                 $aiowps_feature_mgr->check_feature_status_and_recalculate_points();
 
                 $res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
-                if ($res){
+                if ($res) {
                     echo '<div id="message" class="updated fade"><p>';
                     echo $msg;
                     echo '</p></div>';
                 }
-                else if($res == -1){
+                else {
                     $this->show_msg_error(__('Could not write to the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
                 }
             }
@@ -642,7 +642,7 @@ class AIOWPSecurity_Brute_Force_Menu extends AIOWPSecurity_Admin_Menu
                     $this->show_msg_settings_updated();
 
                     $write_result = AIOWPSecurity_Utility_Htaccess::write_to_htaccess(); //now let's write to the .htaccess file
-                    if ($write_result == -1)
+                    if ( !$write_result )
                     {
                         $this->show_msg_error(__('The plugin was unable to write to the .htaccess file. Please edit file manually.','all-in-one-wp-security-and-firewall'));
                         $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_whitelist_Menu - The plugin was unable to write to the .htaccess file.");

--- a/all-in-one-wp-security/admin/wp-security-filesystem-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-filesystem-menu.php
@@ -278,7 +278,7 @@ class AIOWPSecurity_Filesystem_Menu extends AIOWPSecurity_Admin_Menu
             {
                 $this->show_msg_updated(__('You have successfully saved the Prevent Access to Default WP Files configuration.', 'all-in-one-wp-security-and-firewall'));
             }
-            else if($res == -1)
+            else
             {
                 $this->show_msg_error(__('Could not write to the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
             }

--- a/all-in-one-wp-security/admin/wp-security-firewall-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-firewall-menu.php
@@ -118,7 +118,7 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
             {
                 $this->show_msg_updated(__('Settings were successfully saved', 'all-in-one-wp-security-and-firewall'));
             }
-            else if($res == -1)
+            else
             {
                 $this->show_msg_error(__('Could not write to the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
             }
@@ -312,11 +312,11 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
             {
                 $this->show_msg_updated(__('You have successfully saved the Additional Firewall Protection configuration', 'all-in-one-wp-security-and-firewall'));
             }
-            else if($res == -1)
+            else
             {
                 $this->show_msg_error(__('Could not write to the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
             }
-            
+
             if($error)
             {
                 $this->show_msg_error($error);
@@ -533,7 +533,7 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
                 // Recalculate points after the feature status/options have been altered
                 $aiowps_feature_mgr->check_feature_status_and_recalculate_points();
             }
-            else if($res == -1)
+            else
             {
                 $this->show_msg_error(__('Could not write to the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
             }
@@ -721,7 +721,7 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
             {
                 $this->show_msg_updated(__('Settings were successfully saved', 'all-in-one-wp-security-and-firewall'));
             }
-            else if($res == -1)
+            else
             {
                 $this->show_msg_error(__('Could not write to the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
             }
@@ -1014,7 +1014,7 @@ class AIOWPSecurity_Firewall_Menu extends AIOWPSecurity_Admin_Menu
                 $this->show_msg_settings_updated();
 
                 $write_result = AIOWPSecurity_Utility_Htaccess::write_to_htaccess(); //now let's write to the .htaccess file
-                if ($write_result == -1)
+                if ( !$write_result )
                 {
                     $this->show_msg_error(__('The plugin was unable to write to the .htaccess file. Please edit file manually.','all-in-one-wp-security-and-firewall'));
                     $aio_wp_security->debug_logger->log_debug("Custom Rules feature - The plugin was unable to write to the .htaccess file.");

--- a/all-in-one-wp-security/admin/wp-security-list-404.php
+++ b/all-in-one-wp-security/admin/wp-security-list-404.php
@@ -212,12 +212,11 @@ class AIOWPSecurity_List_404 extends AIOWPSecurity_List_Table {
             $aio_wp_security->configs->save_config(); //Save the configuration
 
             $write_result = AIOWPSecurity_Utility_Htaccess::write_to_htaccess(); //now let's write to the .htaccess file
-            if ($write_result == -1)
-            {
+            if ( $write_result ) {
+                AIOWPSecurity_Admin_Menu::show_msg_updated_st(__('The selected IP addresses have been added to the blacklist and will be permanently blocked!', 'WPS'));
+            } else {
                 AIOWPSecurity_Admin_Menu::show_msg_error_st(__('The plugin was unable to write to the .htaccess file. Please edit file manually.','all-in-one-wp-security-and-firewall'));
                 $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_Blacklist_Menu - The plugin was unable to write to the .htaccess file.");
-            }else{
-                AIOWPSecurity_Admin_Menu::show_msg_updated_st(__('The selected IP addresses have been added to the blacklist and will be permanently blocked!', 'WPS'));
             }
         }
         else{

--- a/all-in-one-wp-security/admin/wp-security-list-comment-spammer-ip.php
+++ b/all-in-one-wp-security/admin/wp-security-list-comment-spammer-ip.php
@@ -193,15 +193,14 @@ class AIOWPSecurity_List_Comment_Spammer_IP extends AIOWPSecurity_List_Table {
         if($aio_wp_security->configs->get_value('aiowps_enable_blacklisting')=='1')
         {
             $write_result = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
-            if ($write_result == -1)
+            if ( $write_result )
             {
-                AIOWPSecurity_Admin_Menu::show_msg_error_st(__('The plugin was unable to write to the .htaccess file. Please edit file manually.','all-in-one-wp-security-and-firewall'));
-                $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_Blacklist_Menu - The plugin was unable to write to the .htaccess file.");
+                AIOWPSecurity_Admin_Menu::show_msg_updated_st(__('The .htaccess file was successfully modified to include the selected IP addresses.','all-in-one-wp-security-and-firewall'));
             }
             else
             {
-                
-                AIOWPSecurity_Admin_Menu::show_msg_updated_st(__('The .htaccess file was successfully modified to include the selected IP addresses.','all-in-one-wp-security-and-firewall'));
+                AIOWPSecurity_Admin_Menu::show_msg_error_st(__('The plugin was unable to write to the .htaccess file. Please edit file manually.','all-in-one-wp-security-and-firewall'));
+                $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_Blacklist_Menu - The plugin was unable to write to the .htaccess file.");
             }
         }
         else

--- a/all-in-one-wp-security/admin/wp-security-settings-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-settings-menu.php
@@ -97,7 +97,7 @@ class AIOWPSecurity_Settings_Menu extends AIOWPSecurity_Admin_Menu
             {
                 $this->show_msg_updated(__('All the security features have been disabled successfully!', 'all-in-one-wp-security-and-firewall'));
             }
-            else if($res == -1)
+            else
             {
                 $this->show_msg_error(__('Could not write to the .htaccess file. Please restore your .htaccess file manually using the restore functionality in the ".htaccess File".', 'all-in-one-wp-security-and-firewall'));
             }
@@ -119,12 +119,12 @@ class AIOWPSecurity_Settings_Menu extends AIOWPSecurity_Admin_Menu
             AIOWPSecurity_Configure_Settings::turn_off_all_firewall_rules();
             //Now let's clear the applicable rules from the .htaccess file
             $res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
-            
+
             if ($res)
             {
                 $this->show_msg_updated(__('All firewall rules have been disabled successfully!', 'all-in-one-wp-security-and-firewall'));
             }
-            else if($res == -1)
+            else
             {
                 $this->show_msg_error(__('Could not write to the .htaccess file. Please restore your .htaccess file manually using the restore functionality in the ".htaccess File".', 'all-in-one-wp-security-and-firewall'));
             }
@@ -630,7 +630,7 @@ function render_tab5()
                         //Now let's refresh the .htaccess file with any modified rules if applicable
                         $res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
 
-                        if($res == -1)
+                        if( !$res )
                         {
                             $this->show_msg_error(__('Could not write to the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
                         }

--- a/all-in-one-wp-security/admin/wp-security-spam-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-spam-menu.php
@@ -104,7 +104,7 @@ class AIOWPSecurity_Spam_Menu extends AIOWPSecurity_Admin_Menu
             {
                 $this->show_msg_updated(__('Settings were successfully saved', 'all-in-one-wp-security-and-firewall'));
             }
-            else if($res == -1)
+            else
             {
                 $this->show_msg_error(__('Could not write to the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
             }

--- a/all-in-one-wp-security/classes/wp-security-configure-settings.php
+++ b/all-in-one-wp-security/classes/wp-security-configure-settings.php
@@ -276,9 +276,9 @@ class AIOWPSecurity_Configure_Settings
         
         //Refresh the .htaccess file based on the new settings
         $res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
-        if($res == -1)
+        if( !$res )
         {
-            $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_Configure_Settings::turn_off_all_firewall_rules() - Could not write to the .htaccess file. Please check the file permissions.",4);
+            $aio_wp_security->debug_logger->log_debug(__METHOD__ . " - Could not write to the .htaccess file. Please check the file permissions.",4);
         }
     }
     
@@ -318,9 +318,9 @@ class AIOWPSecurity_Configure_Settings
         //Refresh the .htaccess file based on the new settings
         $res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
 
-        if($res == -1)
+        if( !$res )
         {
-            $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_Configure_Settings::turn_off_all_firewall_rules() - Could not write to the .htaccess file. Please check the file permissions.",4);
+            $aio_wp_security->debug_logger->log_debug(__METHOD__ . " - Could not write to the .htaccess file. Please check the file permissions.",4);
         }
     }
 

--- a/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
+++ b/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
@@ -198,7 +198,7 @@ class AIOWPSecurity_General_Init_Tasks
         //If white list enabled need to re-adjust the .htaccess rules
         if ($aio_wp_security->configs->get_value('aiowps_enable_whitelisting') == '1') {
             $write_result = AIOWPSecurity_Utility_Htaccess::write_to_htaccess(); //now let's write to the .htaccess file
-            if ($write_result == -1)
+            if ( !$write_result )
             {
                 $this->show_msg_error(__('The plugin was unable to write to the .htaccess file. Please edit file manually.','all-in-one-wp-security-and-firewall'));
                 $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_whitelist_Menu - The plugin was unable to write to the .htaccess file.");

--- a/all-in-one-wp-security/classes/wp-security-installer.php
+++ b/all-in-one-wp-security/classes/wp-security-installer.php
@@ -178,7 +178,7 @@ class AIOWPSecurity_Installer
             //Now let's write any rules to the .htaccess file if necessary
             $res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
 
-            if ($res == -1) {
+            if ( !$res ) {
                 $aio_wp_security->debug_logger->log_debug("AIOWPSecurity_Deactivation::run_deactivation_tasks() - Could not write to the .htaccess file. Please check the file permissions.", 4);
                 return false;
             }

--- a/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
@@ -66,35 +66,33 @@ class AIOWPSecurity_Utility_Htaccess
     }
 
 
+    /**
+     * Write all active rules to .htaccess file.
+     *
+     * @return boolean True on success, false on failure.
+     */
     static function write_to_htaccess()
     {
         global $aio_wp_security;
         //figure out what server is being used
         if (AIOWPSecurity_Utility::get_server_type() == -1) {
             $aio_wp_security->debug_logger->log_debug("Unable to write to .htaccess - server type not supported!", 4);
-            return -1; //unable to write to the file
+            return false; //unable to write to the file
         }
 
         //clean up old rules first
         if (AIOWPSecurity_Utility_Htaccess::delete_from_htaccess() == -1) {
             $aio_wp_security->debug_logger->log_debug("Delete operation of .htaccess file failed!", 4);
-            return -1; //unable to write to the file
+            return false; //unable to write to the file
         }
 
         $htaccess = ABSPATH . '.htaccess';
-        //get the subdirectory if it is installed in one
-        $siteurl = explode('/', get_option('siteurl'));
-        if (isset($siteurl[3])) {
-            $dir = '/' . $siteurl[3] . '/';
-        } else {
-            $dir = '/';
-        }
 
         if (!$f = @fopen($htaccess, 'a+')) {
             @chmod($htaccess, 0644);
             if (!$f = @fopen($htaccess, 'a+')) {
                 $aio_wp_security->debug_logger->log_debug("chmod operation on .htaccess failed!", 4);
-                return -1;
+                return false;
             }
         }
         AIOWPSecurity_Utility_File::backup_and_rename_htaccess($htaccess); //TODO - we dont want to continually be backing up the htaccess file
@@ -102,10 +100,6 @@ class AIOWPSecurity_Utility_Htaccess
         $ht = explode(PHP_EOL, implode('', file($htaccess))); //parse each line of file into array
 
         $rules = AIOWPSecurity_Utility_Htaccess::getrules();
-        if ($rules == -1) {
-            $aio_wp_security->debug_logger->log_debug("Unable to retrieve rules in .htaccess file!", 4);
-            return -1;
-        }
 
         $rulesarray = explode(PHP_EOL, $rules);
         $rulesarray = apply_filters('aiowps_htaccess_rules_before_writing', $rulesarray);
@@ -113,7 +107,7 @@ class AIOWPSecurity_Utility_Htaccess
 
         if (!$f = @fopen($htaccess, 'w+')) {
             $aio_wp_security->debug_logger->log_debug("Write operation on .htaccess failed!", 4);
-            return -1; //we can't write to the file
+            return false; //we can't write to the file
         }
 
         $blank = false;
@@ -131,7 +125,7 @@ class AIOWPSecurity_Utility_Htaccess
             }
         }
         @fclose($f);
-        return 1; //success
+        return true; //success
     }
 
     /*


### PR DESCRIPTION
Hi,

I noticed that, in some cases, return value of `write_to_htaccess()` function has been checked incorrectly (example below taken from [here](https://github.com/Arsenal21/all-in-one-wordpress-security/blob/master/all-in-one-wp-security/admin/wp-security-brute-force-menu.php#L132:L138)):
<pre>
$res = AIOWPSecurity_Utility_Htaccess::write_to_htaccess();
if ($res) {
  $this->show_msg_settings_updated();
}
else if($res == -1) {
  $this->show_msg_error(__('Could not delete the Cookie-based directives from the .htaccess file. Please check the file permissions.', 'all-in-one-wp-security-and-firewall'));
}
</pre>

The problem is that [`write_to_htaccess()`](https://github.com/Arsenal21/all-in-one-wordpress-security/blob/master/all-in-one-wp-security/classes/wp-security-utility-htaccess.php#L69) returns 1 on success and -1 on failure, so the `if ($res)` check above always passes and `else if($res == -1)` branch is never tested.

I propose that `write_to_htaccess()` should return boolean value (true on success, false on failure) - it makes more sense and is inherently less prone to such errors. Btw. while refactoring the function, I also removed some obsolete code from it.

There's one more typo fix in the commit that's a bit unrelated to the problem, but I thought it would be useful to mention: PHP 5 has a [`__METHOD__` constant](http://php.net/manual/en/language.constants.predefined.php) that comes very handy in debug messages. It's simpler to type and also helps to avoid [method name typos](https://github.com/Arsenal21/all-in-one-wordpress-security/blob/master/all-in-one-wp-security/classes/wp-security-configure-settings.php#L281) when copy-pasting code snippets from one method to another ;)

There's a lot of changes in the commit, but I think their intention is pretty clear.

Cheers,
Česlav