### PR TITLE
Fix (minor): No need to use strcmp to compare integer values.

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-file-scan.php
+++ b/all-in-one-wp-security/classes/wp-security-file-scan.php
@@ -263,8 +263,8 @@ class AIOWPSecurity_Scan
                 if ( array_key_exists( $entry, $old_scan_minus_deleted ) ) 
                 {
                     //check filesize and last_modified values
-                    if (strcmp($key['last_modified'], $old_scan_minus_deleted[$entry]['last_modified']) != 0 || 
-                                    strcmp($key['filesize'], $old_scan_minus_deleted[$entry]['filesize']) != 0) 
+                    if ( ($key['last_modified'] !== $old_scan_minus_deleted[$entry]['last_modified'])
+                       || ($key['filesize'] !== $old_scan_minus_deleted[$entry]['filesize']) )
                     {
                         $file_changes_detected[$entry]['filesize'] = $key['filesize'];
                         $file_changes_detected[$entry]['last_modified'] = $key['last_modified'];


### PR DESCRIPTION
Hi,

In file scanner data, both '_last_modified_' and '_filesize_' items are integers, so it's uneffective to compare them with `strcmp`.

Btw. I think such minor fixes don't have to be individually mentioned in plugin changelog. Please, consider only mentioning "Minor code fixes and improvements.", it makes the changelog leaner :)

Cheers,
Česlav