### PR TITLE
File scanner codebase cleanup

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-file-scan.php
+++ b/all-in-one-wp-security/classes/wp-security-file-scan.php
@@ -26,9 +26,9 @@ class AIOWPSecurity_Scan
                 $aio_wp_security->configs->set_value('aiowps_fcds_change_detected', TRUE);
                 $aio_wp_security->configs->save_config();
                 $aio_wp_security->debug_logger->log_debug("File Change Detection Feature: change to filesystem detected!");
-                
-                $this->aiowps_send_file_change_alert_email(); //Send file change scan results via email if applicable
-            }else if(empty($scan_result['files_added']) && empty($scan_result['files_removed']) && empty($scan_result['files_changed'])){
+
+                $this->aiowps_send_file_change_alert_email($scan_result); //Send file change scan results via email if applicable
+            } else {
                 //Reset the change flag
                 $aio_wp_security->configs->set_value('aiowps_fcds_change_detected', FALSE);
                 $aio_wp_security->configs->save_config();
@@ -42,8 +42,13 @@ class AIOWPSecurity_Scan
             return $scan_result;
         }
     }
-    
-    function aiowps_send_file_change_alert_email()
+
+    /**
+     * Send email with notification about file changes detected by last scan.
+     * @global AIO_WP_Security $aio_wp_security
+     * @param array $scan_result Array with scan result returned by compare_scan_data() method.
+     */
+    function aiowps_send_file_change_alert_email($scan_result)
     {
         global $aio_wp_security;
         if ( $aio_wp_security->configs->get_value('aiowps_send_fcd_scan_email') == '1' ) 
@@ -56,36 +61,16 @@ class AIOWPSecurity_Scan
             //$attachment = array();
             $message = __( 'A file change was detected on your system for site URL', 'all-in-one-wp-security-and-firewall' ) . ' ' . get_option( 'siteurl' ) . __( '. Scan was generated on', 'all-in-one-wp-security-and-firewall' ) . ' ' . date( 'l, F jS, Y \a\\t g:i a', current_time( 'timestamp' ) );
             $message .= "\r\n\r\n".__( 'A summary of the scan results is shown below:', 'all-in-one-wp-security-and-firewall' );
-            $scan_res_unserialized = self::get_file_change_data();
-            $scan_results_message = '';
-            if($scan_res_unserialized !== false){
-                $scan_results_message = self::get_file_change_summary($scan_res_unserialized);
-            }
-            
             $message .= "\r\n\r\n";
-            $message .= $scan_results_message;
+            $message .= self::get_file_change_summary($scan_result);
             $message .= "\r\n".__( 'Login to your site to view the scan details.', 'all-in-one-wp-security-and-firewall' );
 
-            //Get the email address(es).
+            // Get the email address(es).
             $addresses = $aio_wp_security->configs->get_value('aiowps_fcd_scan_email_address');
-            if ( empty( $addresses ) )
-            {
-                $toaddress = get_site_option( 'admin_email' );
-                $sendMail = wp_mail( $toaddress, $subject, $message, $headers );
-                if(FALSE === $sendMail){
-                    $aio_wp_security->debug_logger->log_debug("File change notification email failed to send to ".$toaddress,4);
-                }
-
-            } else
-            {
-                $email_list_array = explode(PHP_EOL, $addresses);
-                foreach($email_list_array as $key=>$value){
-                    $toaddress = $value;
-                    $sendMail = wp_mail( $toaddress, $subject, $message, $headers );
-                    if(FALSE === $sendMail){
-                        $aio_wp_security->debug_logger->log_debug("File change notification email failed to send to ".$toaddress,4);
-                    }
-                }
+            // If no explicit email address(es) are given, send email to site admin.
+            $to = empty( $addresses ) ? array( get_site_option('admin_email') ) : explode(PHP_EOL, $addresses);
+            if ( !wp_mail( $to, $subject, $message, $headers ) ) {
+                $aio_wp_security->debug_logger->log_debug("File change notification email failed to send.",4);
             }
 
         }
@@ -712,46 +697,42 @@ class AIOWPSecurity_Scan
         }else{
             return $scan_results_unserialized;
         }
-        
+
     }
-    
-    static function get_file_change_summary($scan_results_unserialized)
+
+    static function get_file_change_summary($scan_result)
     {
         $scan_summary = "";
-        $files_added_output = "";
-        $files_removed_output = "";
-        $files_changed_output = "";
-        if (!empty($scan_results_unserialized['files_added']))
+        if (!empty($scan_result['files_added']))
         {
             //Output of files added
-            $files_added_output .= "\r\n".__('The following files were added to your host', 'all-in-one-wp-security-and-firewall').":\r\n";
-            foreach ($scan_results_unserialized['files_added'] as $key=>$value) {
-                $files_added_output .= "\r\n".$key.' ('.__('modified on: ', 'all-in-one-wp-security-and-firewall').date('Y-m-d H:i:s',$value['last_modified']).')';
+            $scan_summary .= "\r\n".__('The following files were added to your host', 'all-in-one-wp-security-and-firewall').":\r\n";
+            foreach ($scan_result['files_added'] as $key=>$value) {
+                $scan_summary .= "\r\n".$key.' ('.__('modified on: ', 'all-in-one-wp-security-and-firewall').date('Y-m-d H:i:s',$value['last_modified']).')';
             }
-            $files_added_output .= "\r\n======================================\r\n";
+            $scan_summary .= "\r\n======================================\r\n";
         }
-        if (!empty($scan_results_unserialized['files_removed']))
+        if (!empty($scan_result['files_removed']))
         {
             //Output of files removed
-            $files_removed_output .= "\r\n".__('The following files were removed from your host', 'all-in-one-wp-security-and-firewall').":\r\n";
-            foreach ($scan_results_unserialized['files_removed'] as $key=>$value) {
-                $files_removed_output .= "\r\n".$key.' ('.__('modified on: ', 'all-in-one-wp-security-and-firewall').date('Y-m-d H:i:s',$value['last_modified']).')';
+            $scan_summary .= "\r\n".__('The following files were removed from your host', 'all-in-one-wp-security-and-firewall').":\r\n";
+            foreach ($scan_result['files_removed'] as $key=>$value) {
+                $scan_summary .= "\r\n".$key.' ('.__('modified on: ', 'all-in-one-wp-security-and-firewall').date('Y-m-d H:i:s',$value['last_modified']).')';
             }
-            $files_removed_output .= "\r\n======================================\r\n";
+            $scan_summary .= "\r\n======================================\r\n";
         }
 
-        if (!empty($scan_results_unserialized['files_changed']))
+        if (!empty($scan_result['files_changed']))
         {
             //Output of files changed
-            $files_changed_output .= "\r\n".__('The following files were changed on your host', 'all-in-one-wp-security-and-firewall').":\r\n";
-            foreach ($scan_results_unserialized['files_changed'] as $key=>$value) {
-                $files_changed_output .= "\r\n".$key.' ('.__('modified on: ', 'all-in-one-wp-security-and-firewall').date('Y-m-d H:i:s',$value['last_modified']).')';
+            $scan_summary .= "\r\n".__('The following files were changed on your host', 'all-in-one-wp-security-and-firewall').":\r\n";
+            foreach ($scan_result['files_changed'] as $key=>$value) {
+                $scan_summary .= "\r\n".$key.' ('.__('modified on: ', 'all-in-one-wp-security-and-firewall').date('Y-m-d H:i:s',$value['last_modified']).')';
             }
-            $files_changed_output .= "\r\n======================================\r\n";
+            $scan_summary .= "\r\n======================================\r\n";
         }
-        
-        $scan_summary .= $files_added_output . $files_removed_output . $files_changed_output;
+
         return $scan_summary;
     }
-    
+
 }


### PR DESCRIPTION
Hello,

I started working on #29 and I noticed some parts of file scanner that could be improved:

1. There's no need to fetch scan result from DB via `get_file_change_data()` in `aiowps_send_file_change_alert_email()` method, because `execute_file_change_detection_scan()` method already has scan result data, so why not just pass it along :)
1. There's no need for extra `empty()` checks in `elseif` branch in `execute_file_change_detection_scan()` - given the checks in `if` condition, it's essentially just `else` branch.
1. All notification emails can be send at once by `wp_mail()`. This introduces a small change in behavior whenever there are multiple notification addresses. As there's only one email send, all addressees are listed in email header. Personally, I consider this as an improvement, because this way one can immediately engage in conversation about reported scan results (just by using Reply To All function).
1. Finally, I removed unnecessary intermediate variables in `get_file_change_summary()` - no need to waste memory on them :)

Greets,
Česlav