### PR TITLE
Code clean-up in AIOWPSecurity_Scan::do_file_change_scan() method.

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-utility.php
+++ b/all-in-one-wp-security/classes/wp-security-utility.php
@@ -7,6 +7,16 @@ class AIOWPSecurity_Utility
         //NOP
     }
 
+    /**
+     * Explode $string with $delimiter, trim all lines and filter out empty ones.
+     * @param string $string
+     * @param string $delimiter
+     * @return array
+     */
+    static function explode_trim_filter_empty($string, $delimiter = PHP_EOL) {
+        return array_filter(array_map('trim', explode($delimiter, $string)), 'strlen');
+    }
+
     static function get_current_page_url()
     {
         $pageURL = 'http';


### PR DESCRIPTION
Hi,

This is continuation of my effort to get #29 implemented. This time I cleaned up the `do_file_change_scan` method:

1. `RecursiveDirectoryIterator` gets `FilesystemIterator::SKIP_DOTS` flag as parameter, so all "." and ".." files are skipped implicitly by iterator, there's no need for `if ($fileinfo->getFilename() == "..")` check.
1. `$files_to_skip` variable is initiated before the main loop instead in the loop - no need to do the same computation in every iteration
1. The iteraror key is absolute path to the file, so no need to retrieve it via `$filename = $fileinfo->getPathname();`.
1. `$file_types_to_skip` variable is an array instead of string and extension are checked via `isset($file_types_to_skip[$ext])`. This makes the check resistant against (rather unlikely but possible) substring mismatches: previously, if someone set "p" as ignored extension, any file with extension having "p" in it (like .php) would be ignored.
1. The `strpos` check against files/dirs in `$files_to_skip` variable now has `$offset` parameter set to `strlen($start_dir)` - the idea is that any file/dir in `$files_to_skip` variable is relative to `$start_dir`, so there's no reason to check the entire file path, only the part of `$filename` after `$start_dir` prefix is relevant for the check. **Important**: this fix avoids a problem one would have if a file/dir pattern matches `ABS_PATH`. In such case, the scanner simply doesn't work, because all files are ignored.
1. There's a 'break;' command added to the loop that checks `$files_to_skip`, because loop can be terminated as soon as match is found.
1. Finally, I noticed that plugin code often reads configuration from `<textarea>` elements, so I allowed myself to introduce new utility method `AIOWPSecurity_Utility::explode_trim_filter_empty` that helps to get clean data in such cases :)

I know this is a rather large change, so take your time to review it.

Greetings,
Česlav