### PR TITLE
Use built-in WordPress functions when applicable.

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-admin-init.php
+++ b/all-in-one-wp-security/admin/wp-security-admin-init.php
@@ -207,27 +207,23 @@ class AIOWPSecurity_Admin_Init
         add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('User Login', 'all-in-one-wp-security-and-firewall'),  __('User Login', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_USER_LOGIN_MENU_SLUG, array(&$this, 'handle_user_login_menu_rendering'));
         add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('User Registration', 'all-in-one-wp-security-and-firewall'),  __('User Registration', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_USER_REGISTRATION_MENU_SLUG, array(&$this, 'handle_user_registration_menu_rendering'));
         add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('Database Security', 'all-in-one-wp-security-and-firewall'),  __('Database Security', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_DB_SEC_MENU_SLUG, array(&$this, 'handle_database_menu_rendering'));
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1){
-            //Suppress the Filesystem Security menu if site is a multi site AND not the main site
-        }else{
+        if ( is_main_site() ) {
+            // Display the Filesystem Security menu only if site is the main site
             add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('Filesystem Security', 'all-in-one-wp-security-and-firewall'),  __('Filesystem Security', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_FILESYSTEM_MENU_SLUG, array(&$this, 'handle_filesystem_menu_rendering'));
         }
         add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('WHOIS Lookup', 'all-in-one-wp-security-and-firewall'),  __('WHOIS Lookup', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_WHOIS_MENU_SLUG, array(&$this, 'handle_whois_menu_rendering'));
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1){
-            //Suppress the Blacklist Manager menu if site is a multi site AND not the main site
-        }else{
+        if ( is_main_site() ) {
+            // Display the Blacklist Manager menu only if site is the main site
             add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('Blacklist Manager', 'all-in-one-wp-security-and-firewall'),  __('Blacklist Manager', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_BLACKLIST_MENU_SLUG, array(&$this, 'handle_blacklist_menu_rendering'));
         }
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1){
-            //Suppress the firewall menu if site is a multi site AND not the main site
-        }else{
+        if ( is_main_site() ) {
+            // Display the firewall menu only if site is the main site
             add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('Firewall', 'all-in-one-wp-security-and-firewall'),  __('Firewall', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_FIREWALL_MENU_SLUG, array(&$this, 'handle_firewall_menu_rendering'));
         }
         add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('Brute Force', 'all-in-one-wp-security-and-firewall'),  __('Brute Force', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_BRUTE_FORCE_MENU_SLUG, array(&$this, 'handle_brute_force_menu_rendering'));
         add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('SPAM Prevention', 'all-in-one-wp-security-and-firewall'),  __('SPAM Prevention', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_SPAM_MENU_SLUG, array(&$this, 'handle_spam_menu_rendering'));
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1){
-            //Suppress the filescan menu if site is a multi site AND not the main site
-        }else{
+        if ( is_main_site() ) {
+            // Display the filescan menu only if site is the main site
             add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('Scanner', 'all-in-one-wp-security-and-firewall'),  __('Scanner', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_FILESCAN_MENU_SLUG, array(&$this, 'handle_filescan_menu_rendering'));
         }
         add_submenu_page(AIOWPSEC_MAIN_MENU_SLUG, __('Maintenance', 'all-in-one-wp-security-and-firewall'),  __('Maintenance', 'all-in-one-wp-security-and-firewall') , AIOWPSEC_MANAGEMENT_PERMISSION, AIOWPSEC_MAINTENANCE_MENU_SLUG, array(&$this, 'handle_maintenance_menu_rendering'));

--- a/all-in-one-wp-security/admin/wp-security-brute-force-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-brute-force-menu.php
@@ -49,7 +49,7 @@ class AIOWPSecurity_Brute_Force_Menu extends AIOWPSecurity_Admin_Menu
         echo '<h2 class="nav-tab-wrapper">';
         foreach ( $this->menu_tabs as $tab_key => $tab_caption ) 
         {
-            if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1
+            if ( !is_main_site()
                 && stristr($tab_caption, "Rename Login Page") === false && stristr($tab_caption, "Login Captcha") === false){
                 //Suppress the all Brute Force menu tabs if site is a multi site AND not the main site except "rename login" and "captcha"
             }else{

--- a/all-in-one-wp-security/admin/wp-security-dashboard-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-dashboard-menu.php
@@ -481,7 +481,7 @@ class AIOWPSecurity_Dashboard_Menu extends AIOWPSecurity_Admin_Menu
                     <div class="inside">
                         <?php
                         $users_online_link = '<a href="admin.php?page=' . AIOWPSEC_USER_LOGIN_MENU_SLUG . '&tab=tab5">Logged In Users</a>';
-                        if (AIOWPSecurity_Utility::is_multisite_install()) {
+                        if ( is_multisite() ) {
                             $logged_in_users = get_site_transient('users_online');
                             $num_users = count($logged_in_users);
                             if ($num_users > 1) {

--- a/all-in-one-wp-security/admin/wp-security-database-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-database-menu.php
@@ -19,7 +19,7 @@ class AIOWPSecurity_Database_Menu extends AIOWPSecurity_Admin_Menu
     
     function set_menu_tabs() 
     {
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1){
+        if ( !is_main_site() ){
             //Suppress the DB prefix change tab if site is a multi site AND not the main site
             $this->menu_tabs = array(
             //'tab1' => __('DB Prefix', 'all-in-one-wp-security-and-firewall'),
@@ -213,7 +213,7 @@ class AIOWPSecurity_Database_Menu extends AIOWPSecurity_Admin_Menu
             if ($result)
             {
                 $backup_file_name = $aio_wp_security->backup_obj->last_backup_file_name;
-                if (function_exists('is_multisite') && is_multisite()) 
+                if ( is_multisite() )
                 {
                     $aiowps_backup_file_path = $aio_wp_security->backup_obj->last_backup_file_dir_multisite . '/' . $backup_file_name;
                 }
@@ -397,9 +397,9 @@ class AIOWPSecurity_Database_Menu extends AIOWPSecurity_Admin_Menu
         else{
             echo '<p class="aio_success_with_icon">'.__('A backup copy of your wp-config.php file was created successfully!', 'all-in-one-wp-security-and-firewall').'</p>';
         }
-        
+
         //Get multisite blog_ids if applicable
-        if (AIOWPSecurity_Utility::is_multisite_install()) {
+        if ( is_multisite() ) {
             $blog_ids = AIOWPSecurity_Utility::get_blog_ids();
         }
 
@@ -476,7 +476,7 @@ class AIOWPSecurity_Database_Menu extends AIOWPSecurity_Admin_Menu
         }
 
         //Now let's update the options tables for the multisite subsites if applicable
-        if (AIOWPSecurity_Utility::is_multisite_install()) {
+        if ( is_multisite() ) {
             if(!empty($blog_ids)){
                 foreach ($blog_ids as $blog_id) {
                     if ($blog_id == 1){continue;} //skip main site

--- a/all-in-one-wp-security/admin/wp-security-list-comment-spammer-ip.php
+++ b/all-in-one-wp-security/admin/wp-security-list-comment-spammer-ip.php
@@ -21,7 +21,7 @@ class AIOWPSecurity_List_Comment_Spammer_IP extends AIOWPSecurity_List_Table {
     function column_comment_author_IP($item){
         $tab = strip_tags($_REQUEST['tab']);
         //Build row actions
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1){
+        if ( !is_main_site() ){
             //Suppress the block link if site is a multi site AND not the main site
             $actions = array(); //blank array
         }else{
@@ -68,17 +68,10 @@ class AIOWPSecurity_List_Comment_Spammer_IP extends AIOWPSecurity_List_Table {
         );
         return $sortable_columns;
     }
-    
+
     function get_bulk_actions() {
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1){
-            //Suppress the block link if site is a multi site AND not the main site
-            $actions = array(); //blank array
-        }else{
-            $actions = array(
-                'block' => 'Block'
-            );
-        }
-        return $actions;
+        // Suppress the block link if site is not the main site
+        return is_main_site() ? array('block' => 'Block') : array();
     }
 
     function process_bulk_action() {

--- a/all-in-one-wp-security/admin/wp-security-list-logged-in-users.php
+++ b/all-in-one-wp-security/admin/wp-security-list-logged-in-users.php
@@ -108,13 +108,13 @@ class AIOWPSecurity_List_Logged_In_Users extends AIOWPSecurity_List_Table {
         $sortable = $this->get_sortable_columns();
 
         $this->_column_headers = array($columns, $hidden, $sortable);
-        
+
         //$this->process_bulk_action();
-    	
+
     	global $wpdb;
         global $aio_wp_security;
 
-        $logged_in_users = (AIOWPSecurity_Utility::is_multisite_install() ? get_site_transient('users_online') : get_transient('users_online'));
+        $logged_in_users = (is_multisite() ? get_site_transient('users_online') : get_transient('users_online'));
         if($logged_in_users !== FALSE){
             foreach ($logged_in_users as $key=>$val)
             {

--- a/all-in-one-wp-security/admin/wp-security-settings-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-settings-menu.php
@@ -317,8 +317,8 @@ class AIOWPSecurity_Settings_Menu extends AIOWPSecurity_Admin_Menu
             </p>';
             ?>
         </div>
-        <?php 
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1)
+        <?php
+        if ( !is_main_site() )
         {
            //Hide config settings if MS and not main site
            AIOWPSecurity_Utility::display_multisite_message();
@@ -428,8 +428,8 @@ class AIOWPSecurity_Settings_Menu extends AIOWPSecurity_Admin_Menu
             </p>';
             ?>
         </div>
-        <?php 
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1)
+        <?php
+        if ( !is_main_site() )
         {
            //Hide config settings if MS and not main site
            AIOWPSecurity_Utility::display_multisite_message();

--- a/all-in-one-wp-security/admin/wp-security-spam-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-spam-menu.php
@@ -152,7 +152,7 @@ class AIOWPSecurity_Spam_Menu extends AIOWPSecurity_Admin_Menu
         <?php
         //Display security info badge
         $aiowps_feature_mgr->output_feature_details_badge("block-spambots");
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1)
+        if ( !is_main_site() )
         {
            //Hide config settings if MS and not main site
            AIOWPSecurity_Utility::display_multisite_message();
@@ -399,7 +399,7 @@ class AIOWPSecurity_Spam_Menu extends AIOWPSecurity_Admin_Menu
         <h3 class="hndle"><label for="title"><?php _e('SPAMMER IP Address Results', 'all-in-one-wp-security-and-firewall'); ?></label></h3>
         <div class="inside">
             <?php
-            if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1)
+            if ( !is_main_site() )
             {
                     echo '<div class="aio_yellow_box">';
                     echo '<p>'.__('The plugin has detected that you are using a Multi-Site WordPress installation.', 'all-in-one-wp-security-and-firewall').'</p>

--- a/all-in-one-wp-security/admin/wp-security-user-accounts-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-user-accounts-menu.php
@@ -93,11 +93,11 @@ class AIOWPSecurity_User_Accounts_Menu extends AIOWPSecurity_Admin_Menu
             </p>';
             ?>
         </div>
-        
+
         <?php
         //display a list of all administrator accounts for this site
         $postbox_title = __('List of Administrator Accounts', 'all-in-one-wp-security-and-firewall');
-        if (AIOWPSecurity_Utility::is_multisite_install()) { //Multi-site: get admin accounts for current site
+        if ( is_multisite() ) { //Multi-site: get admin accounts for current site
           $blog_id = get_current_blog_id();
           $this->postbox($postbox_title, $this->get_all_admin_accounts($blog_id));
         } else {
@@ -272,7 +272,7 @@ class AIOWPSecurity_User_Accounts_Menu extends AIOWPSecurity_Admin_Menu
                     }
 
                     //multisite considerations
-                    if ( AIOWPSecurity_Utility::is_multisite_install() ) { //process sitemeta if we're in a multi-site situation
+                    if ( is_multisite() ) { //process sitemeta if we're in a multi-site situation
                         $oldAdmins = $wpdb->get_var( "SELECT meta_value FROM `" . $wpdb->sitemeta . "` WHERE meta_key = 'site_admins'" );
                         $newAdmins = str_replace( '5:"admin"', strlen( $new_username ) . ':"' . esc_sql( $new_username ) . '"', $oldAdmins );
                         $wpdb->query( "UPDATE `" . $wpdb->sitemeta . "` SET meta_value = '" . esc_sql( $newAdmins ) . "' WHERE meta_key = 'site_admins'" );
@@ -285,8 +285,8 @@ class AIOWPSecurity_User_Accounts_Menu extends AIOWPSecurity_Admin_Menu
                         $after_logout_url = AIOWPSecurity_Utility::get_current_page_url();
                         $after_logout_payload = array('redirect_to'=>$after_logout_url, 'msg'=>$aio_wp_security->user_login_obj->key_login_msg.'=admin_user_changed', );
                         //Save some of the logout redirect data to a transient
-                        AIOWPSecurity_Utility::is_multisite_install() ? set_site_transient('aiowps_logout_payload', $after_logout_payload, 30 * 60) : set_transient('aiowps_logout_payload', $after_logout_payload, 30 * 60);
-                        
+                        is_multisite() ? set_site_transient('aiowps_logout_payload', $after_logout_payload, 30 * 60) : set_transient('aiowps_logout_payload', $after_logout_payload, 30 * 60);
+
                         $logout_url = AIOWPSEC_WP_URL.'?aiowpsec_do_log_out=1';
                         $logout_url = AIOWPSecurity_Utility::add_query_data_to_url($logout_url, 'al_additional_data', '1');
                         AIOWPSecurity_Utility::redirect_to_url($logout_url);

--- a/all-in-one-wp-security/admin/wp-security-user-login-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-user-login-menu.php
@@ -446,11 +446,9 @@ class AIOWPSecurity_User_Login_Menu extends AIOWPSecurity_Admin_Menu
         </div></div>
         <?php
     }
-    
+
     function render_tab5()
     {
-        $logged_in_users = (AIOWPSecurity_Utility::is_multisite_install() ? get_site_transient('users_online') : get_transient('users_online'));
-        
         global $aio_wp_security;
         include_once 'wp-security-list-logged-in-users.php'; //For rendering the AIOWPSecurity_List_Table
         $user_list = new AIOWPSecurity_List_Logged_In_Users();

--- a/all-in-one-wp-security/admin/wp-security-user-registration-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-user-registration-menu.php
@@ -130,7 +130,7 @@ class AIOWPSecurity_User_Registration_Menu extends AIOWPSecurity_Admin_Menu
         <?php
         //Display security info badge
         $aiowps_feature_mgr->output_feature_details_badge("manually-approve-registrations");
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1)
+        if ( !is_main_site() )
         {
            //Hide config settings if MS and not main site
            AIOWPSecurity_Utility::display_multisite_message();
@@ -207,7 +207,7 @@ class AIOWPSecurity_User_Registration_Menu extends AIOWPSecurity_Admin_Menu
         <h3 class="hndle"><label for="title"><?php _e('Registration Page Captcha Settings', 'all-in-one-wp-security-and-firewall'); ?></label></h3>
         <div class="inside">
         <?php
-        if (AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1)
+        if ( !is_main_site() )
         {
             //Hide config settings if MS and not main site
             $special_msg = '<div class="aio_yellow_box">';

--- a/all-in-one-wp-security/classes/wp-security-backup.php
+++ b/all-in-one-wp-security/classes/wp-security-backup.php
@@ -20,7 +20,7 @@ class AIOWPSecurity_Backup
         $is_multi_site = false;
         
         @ini_set( 'auto_detect_line_endings', true );
-        if (function_exists('is_multisite') && is_multisite()) 
+        if ( is_multisite() )
         {
             //Let's get the current site's table prefix
             $site_pref = esc_sql($wpdb->prefix);
@@ -81,10 +81,9 @@ class AIOWPSecurity_Backup
         $return .= PHP_EOL . PHP_EOL;
 
         //Check to see if the main "backups" directory exists - create it otherwise
-        
+
         $aiowps_backup_dir = WP_CONTENT_DIR.'/'.AIO_WP_SECURITY_BACKUPS_DIR_NAME;
-        $aiowps_backup_url = content_url().'/'.AIO_WP_SECURITY_BACKUPS_DIR_NAME;
-        if (!AIOWPSecurity_Utility_File::create_dir($aiowps_backup_dir))
+        if ( !wp_mkdir_p($aiowps_backup_dir) )
         {
             $aio_wp_security->debug_logger->log_debug("Creation of DB backup directory failed!",4);
             return false;
@@ -117,7 +116,7 @@ class AIOWPSecurity_Backup
             $dirpath = $aiowps_backup_dir . '/blogid_' . $blog_id;
 
             //Create a subdirectory for this blog_id
-            if (!AIOWPSecurity_Utility_File::create_dir($dirpath))
+            if ( !wp_mkdir_p($dirpath) )
             {
                 $aio_wp_security->debug_logger->log_debug("Creation failed of DB backup directory for the following multisite blog ID: ".$blog_id,4);
                 return false;

--- a/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
+++ b/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
@@ -124,7 +124,7 @@ class AIOWPSecurity_General_Init_Tasks
         }
 
         //For registration page captcha feature
-        if (AIOWPSecurity_Utility::is_multisite_install()){
+        if ( is_multisite() ){
             $blog_id = get_current_blog_id();
             switch_to_blog($blog_id);
             if($aio_wp_security->configs->get_value('aiowps_enable_registration_page_captcha') == '1'){
@@ -145,7 +145,7 @@ class AIOWPSecurity_General_Init_Tasks
         }
 
         //For comment captcha feature
-        if (AIOWPSecurity_Utility::is_multisite_install()){
+        if ( is_multisite() ){
             $blog_id = get_current_blog_id();
             switch_to_blog($blog_id);
             if($aio_wp_security->configs->get_value('aiowps_enable_comment_captcha') == '1'){
@@ -281,9 +281,9 @@ class AIOWPSecurity_General_Init_Tasks
         if(is_user_logged_in()){
             $current_user_ip = AIOWPSecurity_Utility_IP::get_user_ip_address();
             // get the logged in users list from transients entry
-            $logged_in_users = (AIOWPSecurity_Utility::is_multisite_install() ? get_site_transient('users_online') : get_transient('users_online'));
+            $logged_in_users = (is_multisite() ? get_site_transient('users_online') : get_transient('users_online'));
             $current_user = wp_get_current_user();
-            $current_user = $current_user->ID;  
+            $current_user = $current_user->ID;
             $current_time = current_time('timestamp');
 
             $current_user_info = array("user_id" => $current_user, "last_activity" => $current_time, "ip_address" => $current_user_ip); //We will store last activity time and ip address in transient entry
@@ -291,7 +291,7 @@ class AIOWPSecurity_General_Init_Tasks
             if($logged_in_users === false || $logged_in_users == NULL){
                 $logged_in_users = array();
                 $logged_in_users[] = $current_user_info;
-                AIOWPSecurity_Utility::is_multisite_install() ? set_site_transient('users_online', $logged_in_users, 30 * 60) : set_transient('users_online', $logged_in_users, 30 * 60);
+                is_multisite() ? set_site_transient('users_online', $logged_in_users, 30 * 60) : set_transient('users_online', $logged_in_users, 30 * 60);
             }
             else
             {
@@ -320,17 +320,17 @@ class AIOWPSecurity_General_Init_Tasks
                 {
                     //Update transient if the last activity was less than 15 min ago for this user
                     $logged_in_users[$item_index] = $current_user_info;
-                    AIOWPSecurity_Utility::is_multisite_install() ? set_site_transient('users_online', $logged_in_users, 30 * 60) : set_transient('users_online', $logged_in_users, 30 * 60);
+                    is_multisite() ? set_site_transient('users_online', $logged_in_users, 30 * 60) : set_transient('users_online', $logged_in_users, 30 * 60);
                 }else if($do_nothing){
                     //Do nothing
                 }else{
                     $logged_in_users[] = $current_user_info;
-                    AIOWPSecurity_Utility::is_multisite_install() ? set_site_transient('users_online', $logged_in_users, 30 * 60) : set_transient('users_online', $logged_in_users, 30 * 60);
+                    is_multisite() ? set_site_transient('users_online', $logged_in_users, 30 * 60) : set_transient('users_online', $logged_in_users, 30 * 60);
                 }
             }
         }
     }
-    
+
     function insert_captcha_custom_login($cust_html_code, $args)
     {
         global $aio_wp_security;

--- a/all-in-one-wp-security/classes/wp-security-installer.php
+++ b/all-in-one-wp-security/classes/wp-security-installer.php
@@ -7,7 +7,7 @@ class AIOWPSecurity_Installer
     static function run_installer()
     {
         global $wpdb;
-        if (function_exists('is_multisite') && is_multisite()) {
+        if ( is_multisite() ) {
             // check if it is a network activation - if so, run the activation function for each blog id
             if (isset($_GET['networkwide']) && ($_GET['networkwide'] == 1)) {
                 $old_blog = $wpdb->blogid;
@@ -138,26 +138,24 @@ class AIOWPSecurity_Installer
         global $aio_wp_security;
         //Create our folder in the "wp-content" directory
         $aiowps_dir = WP_CONTENT_DIR . '/' . AIO_WP_SECURITY_BACKUPS_DIR_NAME;
-        if (!is_dir($aiowps_dir)) {
-            mkdir($aiowps_dir, 0755, true);
+        if ( wp_mkdir_p($aiowps_dir) ) {
             //Let's also create an empty index.html file in this folder
-            $index_file = $aiowps_dir . '/index.html';
-            $handle = fopen($index_file, 'w'); //or die('Cannot open file:  '.$index_file);
-            fclose($handle);
-        }
-        $server_type = AIOWPSecurity_Utility::get_server_type();
-        //Only create .htaccess if server is the right type
-        if ($server_type == 'apache' || $server_type == 'litespeed') {
-            $file = $aiowps_dir . '/.htaccess';
-            if (!file_exists($file)) {
-                //Create an .htacces file
-                //Write some rules which will only allow people originating from wp admin page to download the DB backup
-                $rules = '';
-                $rules .= 'order deny,allow' . PHP_EOL;
-                $rules .= 'deny from all' . PHP_EOL;
-                $write_result = file_put_contents($file, $rules);
-                if ($write_result === false) {
-                    $aio_wp_security->debug_logger->log_debug("Creation of .htaccess file in " . AIO_WP_SECURITY_BACKUPS_DIR_NAME . " directory failed!", 4);
+            file_put_contents($aiowps_dir . '/index.html', '');
+
+            $server_type = AIOWPSecurity_Utility::get_server_type();
+            //Only create .htaccess if server is the right type
+            if ($server_type == 'apache' || $server_type == 'litespeed') {
+                $file = $aiowps_dir . '/.htaccess';
+                if (!file_exists($file)) {
+                    //Create an .htacces file
+                    //Write some rules which will only allow people originating from wp admin page to download the DB backup
+                    $rules = '';
+                    $rules .= 'order deny,allow' . PHP_EOL;
+                    $rules .= 'deny from all' . PHP_EOL;
+                    $write_result = file_put_contents($file, $rules);
+                    if ($write_result === false) {
+                        $aio_wp_security->debug_logger->log_debug("Creation of .htaccess file in " . AIO_WP_SECURITY_BACKUPS_DIR_NAME . " directory failed!", 4);
+                    }
                 }
             }
         }

--- a/all-in-one-wp-security/classes/wp-security-user-login.php
+++ b/all-in-one-wp-security/classes/wp-security-user-login.php
@@ -391,11 +391,11 @@ class AIOWPSecurity_User_Login
                 {
                     $aio_wp_security->debug_logger->log_debug("Force Logout - This user logged in more than (".$logout_time_interval_value.") minutes ago. Doing a force log out for the user with username: ".$current_user->user_login);
                     $this->wp_logout_action_handler(); //this will register the logout time/date in the logout_date column
-                    
+
                     $curr_page_url = AIOWPSecurity_Utility::get_current_page_url();
                     $after_logout_payload = array('redirect_to'=>$curr_page_url, 'msg'=>$this->key_login_msg.'=session_expired');
                     //Save some of the logout redirect data to a transient
-                    AIOWPSecurity_Utility::is_multisite_install() ? set_site_transient('aiowps_logout_payload', $after_logout_payload, 30 * 60) : set_transient('aiowps_logout_payload', $after_logout_payload, 30 * 60);
+                    is_multisite() ? set_site_transient('aiowps_logout_payload', $after_logout_payload, 30 * 60) : set_transient('aiowps_logout_payload', $after_logout_payload, 30 * 60);
                     $logout_url = AIOWPSEC_WP_URL.'?aiowpsec_do_log_out=1';
                     $logout_url = AIOWPSecurity_Utility::add_query_data_to_url($logout_url, 'al_additional_data', '1');
                     AIOWPSecurity_Utility::redirect_to_url($logout_url);
@@ -473,9 +473,7 @@ class AIOWPSecurity_User_Login
      */
     function update_user_online_transient($user_id, $ip_addr) 
     {
-        global $aio_wp_security;
-        $logged_in_users = (AIOWPSecurity_Utility::is_multisite_install() ? get_site_transient('users_online') : get_transient('users_online'));
-        //$logged_in_users = get_transient('users_online');
+        $logged_in_users = (is_multisite() ? get_site_transient('users_online') : get_transient('users_online'));
         if ($logged_in_users === false || $logged_in_users == NULL)
         {
             return;
@@ -490,12 +488,10 @@ class AIOWPSecurity_User_Login
             }
             $j++;
         }
-        //Save the transient
-        AIOWPSecurity_Utility::is_multisite_install() ? set_site_transient('users_online', $logged_in_users, 30 * 60) : set_transient('users_online', $logged_in_users, 30 * 60);
-        //set_transient('users_online', $logged_in_users, 30 * 60); //Set transient with the data obtained above and also set the expiry to 30min
-        return;
+        // Set transient with the data obtained above and also set the expiry to 30min
+        is_multisite() ? set_site_transient('users_online', $logged_in_users, 30 * 60) : set_transient('users_online', $logged_in_users, 30 * 60);
     }
-    
+
     /**
      * The handler for the WP "login_message" filter
      * Adds custom messages to the other messages that appear above the login form.

--- a/all-in-one-wp-security/classes/wp-security-utility-file.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-file.php
@@ -75,7 +75,7 @@ class AIOWPSecurity_Utility_File
         
         //Check to see if the main "backups" directory exists - create it otherwise
         $aiowps_backup_dir = WP_CONTENT_DIR.'/'.AIO_WP_SECURITY_BACKUPS_DIR_NAME;
-        if (!AIOWPSecurity_Utility_File::create_dir($aiowps_backup_dir))
+        if ( !wp_mkdir_p($aiowps_backup_dir) )
         {
             $aio_wp_security->debug_logger->log_debug("backup_and_rename_wp_config - Creation of backup directory failed!",4);
             return false;
@@ -98,7 +98,7 @@ class AIOWPSecurity_Utility_File
         
         //Check to see if the main "backups" directory exists - create it otherwise
         $aiowps_backup_dir = WP_CONTENT_DIR.'/'.AIO_WP_SECURITY_BACKUPS_DIR_NAME;
-        if (!AIOWPSecurity_Utility_File::create_dir($aiowps_backup_dir))
+        if ( !wp_mkdir_p($aiowps_backup_dir) )
         {
             $aio_wp_security->debug_logger->log_debug("backup_and_rename_htaccess - Creation of backup directory failed!",4);
             return false;
@@ -374,25 +374,6 @@ class AIOWPSecurity_Utility_File
         return $result;
     }
 
-    /*
-     * Checks if a directory exists and creates one if it does not
-     */
-    static function create_dir($dirpath='')
-    {
-        $res = true;
-        if ($dirpath != '')
-        {
-            //TODO - maybe add some checks to make sure someone is not passing a path with a filename, ie, something which has ".<extenstion>" at the end
-            //$path_parts = pathinfo($dirpath);
-            //$dirpath = $path_parts['dirname'] . '/' . $path_parts['basename'];
-            if (!file_exists($dirpath))
-            {
-                $res = mkdir($dirpath, 0755);
-            }
-        }
-        return $res;
-    }
-
     static function get_attachment_id_from_url($attachment_url = '')
     {
         global $wpdb;
@@ -434,7 +415,5 @@ class AIOWPSecurity_Utility_File
         }
         return ($files) ? $files : false;
     }
-
-
 
 }

--- a/all-in-one-wp-security/classes/wp-security-utility.php
+++ b/all-in-one-wp-security/classes/wp-security-utility.php
@@ -19,17 +19,12 @@ class AIOWPSecurity_Utility
 
     static function get_current_page_url()
     {
-        $pageURL = 'http';
-        if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {
-            $pageURL .= "s";
-        }
-        $pageURL .= "://";
-        if ($_SERVER["SERVER_PORT"] != "80") {
-            $pageURL .= $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["REQUEST_URI"];
-        } else {
-            $pageURL .= $_SERVER["SERVER_NAME"] . $_SERVER["REQUEST_URI"];
-        }
-        return $pageURL;
+        return
+              is_ssl() ? 'https://' : 'http://'
+            . $_SERVER["SERVER_NAME"]
+            . $_SERVER["SERVER_PORT"] != "80" ? (":" . $_SERVER["SERVER_PORT"]) : ""
+            . $_SERVER["REQUEST_URI"]
+        ;
     }
 
     static function redirect_to_url($url, $delay = '0', $exit = '1')
@@ -65,8 +60,8 @@ class AIOWPSecurity_Utility
             return false;
         }
 
-        //If multisite 
-        if (AIOWPSecurity_Utility::is_multisite_install()) {
+        //If multisite
+        if ( is_multisite() ) {
             $blog_id = get_current_blog_id();
             $admin_users = get_users('blog_id=' . $blog_id . '&orderby=login&role=administrator');
             foreach ($admin_users as $user) {
@@ -165,11 +160,6 @@ class AIOWPSecurity_Utility
             return $_COOKIE[$cookie_name];
         }
         return "";
-    }
-
-    static function is_multisite_install()
-    {
-        return function_exists('is_multisite') && is_multisite();
     }
 
     //This is a general yellow box message for when we want to suppress a feature's config items because site is subsite of multi-site
@@ -429,7 +419,7 @@ class AIOWPSecurity_Utility
     static function get_blog_ids()
     {
         global $wpdb;
-        if (AIOWPSecurity_Utility::is_multisite_install()) {
+        if ( is_multisite() ) {
             global $wpdb;
             $blog_ids = $wpdb->get_col("SELECT blog_id FROM " . $wpdb->prefix . "blogs");
         } else {

--- a/all-in-one-wp-security/wp-security-core.php
+++ b/all-in-one-wp-security/wp-security-core.php
@@ -149,7 +149,7 @@ class AIO_WP_Security{
         AIOWPSecurity_Deactivation::run_deactivation_tasks();
         wp_clear_scheduled_hook('aiowps_hourly_cron_event');
         wp_clear_scheduled_hook('aiowps_daily_cron_event');
-        if (AIOWPSecurity_Utility::is_multisite_install()){
+        if ( is_multisite() ){
             delete_site_transient('users_online');
         }
         else{
@@ -245,7 +245,7 @@ class AIO_WP_Security{
                 }
 
                 //Inspect the payload and do redirect to login page with a msg and redirect url
-                $logout_payload = (AIOWPSecurity_Utility::is_multisite_install() ? get_site_transient('aiowps_logout_payload') : get_transient('aiowps_logout_payload'));
+                $logout_payload = ( is_multisite() ? get_site_transient('aiowps_logout_payload') : get_transient('aiowps_logout_payload') );
                 if(!empty($logout_payload['redirect_to'])){
                     $login_url = AIOWPSecurity_Utility::add_query_data_to_url($login_url,'redirect_to',$logout_payload['redirect_to']);
                 }


### PR DESCRIPTION
Hi,

I noticed that plugin implements some functionality that is directly available in WordPress or does not use some useful WordPress functions, so I fixed some most obvious cases - see below:

Helper method `AIOWPSecurity_Utility::is_multisite_install()` can be replaced with direct call to `is_multisite()`. There's no need to check if `function_exists('is_multisite')` as the helper method does - `is_multisite()` is [defined](https://github.com/WordPress/WordPress/blob/master/wp-includes/load.php#L788) in _wp-includes/load.php_ and this file is included at [the very beginning](https://github.com/WordPress/WordPress/blob/master/wp-settings.php#L21) of _wp-settings.php_.

The check if the code runs within the main site (either the single site or the main site in multisite install) can be done via [is_main_site](https://developer.wordpress.org/reference/functions/is_main_site/) function :) This way `AIOWPSecurity_Utility::is_multisite_install() && get_current_blog_id() != 1` can be translated as `!is_main_site()`. This is a bugfix as well, because the `get_current_blog_id() != 1` check assumes that main site has always `blog_id = 1`, which doesn't have to be true.

WordPress has helper function for directory creation `wp_mkdir_p()` that is superior to `AIOWPSecurity_Utility_File::create_dir` in two main aspects:

1. It can create directories recursively.
1. It attempts to set correct file permissions.

WordPress also has helper function for SSL check `is_ssl()` that is also bit more advanced than current check.

Finally, there are two slightly unrelated changes:

1. `$logged_in_users` variable is unused in `render_tab5()` method in _admin/wp-security-user-login-menu.php_.
2. I refactored `run_installer()` method: `file_put_contents` is used to create _index.html_ file and `.htaccess` file in backup directory is created and populated only if the directory has been created.

Less code, but more compatibility with WordPress :)

Greets,
Česlav