### PR TITLE
Partial Apache 2.3 compatibility

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
@@ -891,11 +891,21 @@ class AIOWPSecurity_Utility_Htaccess
                         <IfModule mod_setenvif.c>
                                 SetEnvIfNoCase User-Agent ([a-z0-9]{2000}) bad_bot
                                 SetEnvIfNoCase User-Agent (archive.org|binlar|casper|checkpriv|choppy|clshttp|cmsworld|diavol|dotbot|extract|feedfinder|flicky|g00g1e|harvest|heritrix|httrack|kmccrew|loader|miner|nikto|nutch|planetwork|postrank|purebot|pycurl|python|seekerspider|siclab|skygrid|sqlmap|sucker|turnit|vikspider|winhttp|xxxyy|youda|zmeu|zune) bad_bot
-                                <limit GET POST PUT>
-                                        Order Allow,Deny
-                                        Allow from all
-                                        Deny from env=bad_bot
-                                </limit>
+
+                                # Apache < 2.3
+                                <IfModule !mod_authz_core.c>
+                                    Order allow,deny
+                                    Allow from all
+                                    Deny from env=bad_bot
+                                </IfModule>
+
+                                # Apache >= 2.3
+                                <IfModule mod_authz_core.c>
+                                    <RequireAll>
+                                    Require all granted
+                                    Require not env bad_bot
+                                    </RequireAll>
+                                </IfModule>
                         </IfModule>' . PHP_EOL;
             $rules .= AIOWPSecurity_Utility_Htaccess::$six_g_blacklist_marker_end . PHP_EOL; //Add feature marker end
         }

--- a/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-htaccess.php
@@ -1074,6 +1074,7 @@ class AIOWPSecurity_Utility_Htaccess
 </Files>
 
 END;
-        // Keep the empty line, otherwise there is no end-of-line character at the end!
+        // Keep the empty line at the end of heredoc string,
+        // otherwise the string will not end with end-of-line character!
     }
 }


### PR DESCRIPTION
Hi,

This pull request adds Apache 2.3 (and newer) compatibility that is [yet missing in the plugin](https://wordpress.org/support/topic/apache-24-wrong-htaccess-rules-applied) to the following firewall rules:

- Default WP files access
- Basic firewall settings
- Pingback protection
- Debug log file protection
- 6G firewall

Some notable features that yet need fixing in order to work under Apache 2.3 and newer:

- Blacklist manager
- Login whitelist

Greetings,
Česlav