### PR TITLE
Only activate copy (right-click) protection for non-admin users.

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-misc-options-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-misc-options-menu.php
@@ -100,6 +100,7 @@ class AIOWPSecurity_Misc_Options_Menu extends AIOWPSecurity_Admin_Menu
         <div class="aio_blue_box">
             <?php
             echo '<p>'.__('This feature allows you to disable the ability to select and copy text from your front end.', 'all-in-one-wp-security-and-firewall').'</p>';
+            echo '<p>'.__('When admin user is logged in, the feature is automatically disabled for his session.', 'all-in-one-wp-security-and-firewall').'</p>';
             ?>
         </div>
         <table class="form-table">

--- a/all-in-one-wp-security/classes/wp-security-wp-footer-content.php
+++ b/all-in-one-wp-security/classes/wp-security-wp-footer-content.php
@@ -8,8 +8,9 @@ class AIOWPSecurity_WP_Footer_Content {
 
         global $aio_wp_security;
 
-        //Handle the copy protection feature
-        if ($aio_wp_security->configs->get_value('aiowps_copy_protection') == '1') {
+        // Activate the copy protection feature for non-admin users
+        $copy_protection_active = $aio_wp_security->configs->get_value('aiowps_copy_protection') == '1';
+        if ( $copy_protection_active && !current_user_can(AIOWPSEC_MANAGEMENT_PERMISSION) ) {
             $this->output_copy_protection_code();
         }
 


### PR DESCRIPTION
[Requested](https://wordpress.org/support/topic/feature-request-right-click-for-admins/) on support forums. Makes sense to me - any admin user can bypass this protection anyway by simply turning the feature off.