### PR TITLE
Fix: do not schedule a cronjob, if it is already scheduled.

### DIFF
--- a/all-in-one-wp-security/wp-security-core.php
+++ b/all-in-one-wp-security/wp-security-core.php
@@ -136,9 +136,13 @@ class AIO_WP_Security{
         include_once ('classes/wp-security-installer.php');
         AIOWPSecurity_Installer::run_installer();
 
-        wp_schedule_event(time(), 'hourly', 'aiowps_hourly_cron_event'); //schedule an hourly cron event
-        wp_schedule_event(time(), 'daily', 'aiowps_daily_cron_event'); //schedule an daily cron event
-        
+        if ( !wp_next_scheduled('aiowps_hourly_cron_event') ) {
+            wp_schedule_event(time(), 'hourly', 'aiowps_hourly_cron_event'); //schedule an hourly cron event
+        }
+        if ( !wp_next_scheduled('aiowps_daily_cron_event') ) {
+            wp_schedule_event(time(), 'daily', 'aiowps_daily_cron_event'); //schedule an daily cron event
+        }
+
         do_action('aiowps_activation_complete');
     }
     


### PR DESCRIPTION
Hi,

This fix should prevent scheduling duplicate cron jobs - this can happen, if plugin is uninstalled in a non-standard way (for example by removing/renaming plugin folder) and then activated again.

Despite that I noticed this issue while I was investigating what can be the cause of [recently](https://wordpress.org/support/topic/backups-creating-multiple-files/) [reported](https://wordpress.org/support/topic/database-backup-not-working-anymore-and-fill-up-server/) [problems](https://wordpress.org/support/topic/thanks-for-filling-up-my-100gb-vps/) with too many backup files created, I cannot say whether this fix solves these problems, because I was unable to reproduce them in my environment.

Greetings,
Česlav