### PR TITLE
Minor fix: Drop unnecessary WHERE clause in some backend listings.

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-list-login-fails.php
+++ b/all-in-one-wp-security/admin/wp-security-list-login-fails.php
@@ -164,8 +164,8 @@ class AIOWPSecurity_List_Login_Failed_Attempts extends AIOWPSecurity_List_Table 
 
         $orderby = AIOWPSecurity_Utility::sanitize_value_by_array($orderby, $sortable);
         $order = AIOWPSecurity_Utility::sanitize_value_by_array($order, array('DESC' => '1', 'ASC' => '1'));
-        
-	$data = $wpdb->get_results($wpdb->prepare("SELECT * FROM $failed_logins_table_name WHERE id > %d ORDER BY $orderby $order", -1), ARRAY_A); //Note: had to deliberately introduce WHERE clause because you need at least 2 arguments in prepare statement. Cannot use order/orderby
+
+	$data = $wpdb->get_results("SELECT * FROM $failed_logins_table_name ORDER BY $orderby $order", ARRAY_A);
         $current_page = $this->get_pagenum();
         $total_items = count($data);
         $data = array_slice($data,(($current_page-1)*$per_page),$per_page);

--- a/all-in-one-wp-security/admin/wp-security-list-permanent-blocked-ip.php
+++ b/all-in-one-wp-security/admin/wp-security-list-permanent-blocked-ip.php
@@ -163,7 +163,7 @@ class AIOWPSecurity_List_Blocked_IP extends AIOWPSecurity_List_Table
             $search_term = trim($_POST['s']);
             $data = $wpdb->get_results($wpdb->prepare("SELECT * FROM " . $block_table_name . " WHERE `blocked_ip` LIKE '%%%s%%' OR `block_reason` LIKE '%%%s%%' OR `country_origin` LIKE '%%%s%%' OR `blocked_date` LIKE '%%%s%%'", $search_term, $search_term, $search_term, $search_term), ARRAY_A);
         } else {
-            $data = $wpdb->get_results($wpdb->prepare("SELECT * FROM " . $block_table_name . " WHERE id > %d ORDER BY $orderby $order", -1), ARRAY_A);
+            $data = $wpdb->get_results("SELECT * FROM " . $block_table_name . " ORDER BY $orderby $order", ARRAY_A);
         }
 
         $current_page = $this->get_pagenum();


### PR DESCRIPTION
Hi,

It's not necessary to use `$wpdb->prepare()` on SQL query, if there's nothing to prepare, ie. the query has no arguments to format. The artificial WHERE clause only makes the query slower.

Cheers,
Česlav