### PR TITLE
Clean up last backup file name handling - only path to the last backup file is necessary.

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-database-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-database-menu.php
@@ -212,23 +212,13 @@ class AIOWPSecurity_Database_Menu extends AIOWPSecurity_Admin_Menu
             $result = $aio_wp_security->backup_obj->execute_backup();
             if ($result)
             {
-                $backup_file_name = $aio_wp_security->backup_obj->last_backup_file_name;
-                if (function_exists('is_multisite') && is_multisite()) 
-                {
-                    $aiowps_backup_file_path = $aio_wp_security->backup_obj->last_backup_file_dir_multisite . '/' . $backup_file_name;
-                }
-                else
-                {
-                    $aiowps_backup_dir = WP_CONTENT_DIR.'/'.AIO_WP_SECURITY_BACKUPS_DIR_NAME;
-                    $aiowps_backup_file_path = $aiowps_backup_dir. '/' . $backup_file_name;
-                }
                 echo '<div id="message" class="updated fade"><p>';
                 _e('DB Backup was successfully completed! You will receive the backup file via email if you have enabled "Send Backup File Via Email", otherwise you can retrieve it via FTP from the following directory:','all-in-one-wp-security-and-firewall');
                 echo '</p><p>';
                 _e('Your DB Backup File location: ');
-                echo '<strong>'.$aiowps_backup_file_path.'</strong>';
+                echo '<strong>'.$aio_wp_security->backup_obj->last_backup_file_path.'</strong>';
                 echo '</p></div>';
-            } 
+            }
             else
             {
                 $aio_wp_security->debug_logger->log_debug("DB Backup - Backup operation failed!",4);

--- a/all-in-one-wp-security/classes/wp-security-backup.php
+++ b/all-in-one-wp-security/classes/wp-security-backup.php
@@ -1,11 +1,9 @@
 <?php
 class AIOWPSecurity_Backup
 {
-    var $last_backup_file_name;//Stores the name of the last backup file when execute_backup function is called
-    var $last_backup_file_path;
-    var $last_backup_file_dir_multisite;
-    
-    function __construct() 
+    var $last_backup_file_path; // Stores the path to the last backup file when execute_backup function is called
+
+    function __construct()
     {
         add_action('aiowps_perform_scheduled_backup_tasks', array(&$this, 'aiowps_scheduled_backup_handler'));
         add_action('aiowps_perform_db_cleanup_tasks', array(&$this, 'aiowps_scheduled_db_cleanup_handler'));
@@ -196,13 +194,9 @@ class AIOWPSecurity_Backup
         {
             $fileext = '.sql';
         }
-        $this->last_backup_file_name = $file . $fileext;//database-backup-YYYYMMDD-HHIISS-<random-string>.zip or database-backup-YYYYMMDD-HHIISS-<random-string>.sql
+
         $this->last_backup_file_path = $dirpath . '/' . $file . $fileext;
-        if ($is_multi_site)
-        {
-            $this->last_backup_file_dir_multisite = $aiowps_backup_dir . '/blogid_' . $blog_id; 
-        }
-        
+
         $this->aiowps_send_backup_email(); //Send backup file via email if applicable
         $this->aiowps_delete_backup_files();
         return true;


### PR DESCRIPTION
The subject says it all. No side-effects, just cleaner code.