### PR TITLE
Fix: fall back to default DB backup interval in case of invalid value.

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-backup.php
+++ b/all-in-one-wp-security/classes/wp-security-backup.php
@@ -282,6 +282,7 @@ class AIOWPSecurity_Backup
                     $interval = 'days';
                     break;
                 case '2':
+                default: // Fall back to default value, if config is corrupted for some reason.
                     $interval = 'weeks';
                     break;
             }


### PR DESCRIPTION
Not sure, if this solves the [database](https://wordpress.org/support/topic/automated-backups-filling-up-space/#post-8420085) [backup](https://wordpress.org/support/topic/backups-creating-multiple-files/) [issues](https://wordpress.org/support/topic/thanks-for-filling-up-my-100gb-vps/), but if `$interval` is not set, the backup routine is executed every time cron job runs.