### PR TITLE
Debug logger improvements

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-dashboard-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-dashboard-menu.php
@@ -819,7 +819,8 @@ class AIOWPSecurity_Dashboard_Menu extends AIOWPSecurity_Admin_Menu
 
     function render_tab5()
     {
-        $file_selected = '';
+        global $aio_wp_security;
+        $file_selected = filter_input(INPUT_POST, 'aiowps_log_file'); // Get the selected file
 
         ?>
         <div class="postbox">
@@ -859,20 +860,15 @@ class AIOWPSecurity_Dashboard_Menu extends AIOWPSecurity_Admin_Menu
             </div>
         </div>
         <?php
-        if (isset($_POST['aiowps_view_logs']))//Do form submission tasks
+        if (isset($_POST['aiowps_view_logs']) && $file_selected)//Do form submission tasks
         {
-            $error = '';
-
-            //Check nonce before doing anything 
+            //Check nonce before doing anything
             $nonce = $_REQUEST['_wpnonce'];
             if (!wp_verify_nonce($nonce, 'aiowpsec-dashboard-logs-nonce')) {
                 $aio_wp_security->debug_logger->log_debug("Nonce check failed on dashboard view logs!", 4);
                 wp_die("Error! Nonce check failed on dashboard view logs!");
             }
 
-            //Get the selected file
-            $file_selected = isset($_POST["aiowps_log_file"]) ? sanitize_text_field($_POST["aiowps_log_file"]) : '';
-            
             //Let's make sure that the file selected can only ever be the correct log file of this plugin.
             $valid_aiowps_log_files = array('wp-security-log.txt', 'wp-security-log-cron-job.txt');
             if(!in_array($file_selected, $valid_aiowps_log_files)){

--- a/all-in-one-wp-security/classes/wp-security-debug-logger.php
+++ b/all-in-one-wp-security/classes/wp-security-debug-logger.php
@@ -26,13 +26,7 @@ class AIOWPSecurity_Logger
     
     function get_debug_status($level)
     {
-        $size = count($this->debug_status);
-        if($level >= $size){
-            return 'UNKNOWN';
-        }
-        else{
-            return $this->debug_status[$level];
-        }
+        return isset($this->debug_status[$level]) ? $this->debug_status[$level] : 'UNKNOWN';
     }
     
     function get_section_break($section_break)

--- a/all-in-one-wp-security/classes/wp-security-debug-logger.php
+++ b/all-in-one-wp-security/classes/wp-security-debug-logger.php
@@ -73,28 +73,7 @@ class AIOWPSecurity_Logger
 
     function log_debug_cron($message,$level=0,$section_break=false)
     {
-        global $aio_wp_security;
-        $debug_config = $aio_wp_security->configs->get_value('aiowps_enable_debug');
-        $this->debug_enabled = empty($debug_config)?false:true;
+        $this->log_debug($message, $level, $section_break, $this->default_log_file_cron);
+    }
 
-        if (!$this->debug_enabled) return;
-        $content = $this->get_debug_timestamp();//Timestamp
-        $content .= $this->get_debug_status($level);//Debug status
-        $content .= ' : ';
-        $content .= $message . "\n";
-        $content .= $this->get_section_break($section_break);
-        //$file_name = $this->default_log_file_cron;
-        $this->append_to_file($content, $this->default_log_file_cron);
-    }
-    
-    //TODO - this function need to be completed
-    static function log_debug_st($message,$level=0,$section_break=false,$file_name='')
-    {
-        $content = "\n". $message . "\n";
-        $debug_log_file = 'wp-security-log-static.txt';
-        //$debug_log_file =  AIO_WP_SECURITY_PATH .'/wp-security-log.txt';
-        $fp=fopen($debug_log_file,'a');
-        fwrite($fp, $content);
-        fclose($fp);
-    }
 }

--- a/all-in-one-wp-security/classes/wp-security-debug-logger.php
+++ b/all-in-one-wp-security/classes/wp-security-debug-logger.php
@@ -13,9 +13,10 @@ class AIOWPSecurity_Logger
     var $debug_status = array('SUCCESS','STATUS','NOTICE','WARNING','FAILURE','CRITICAL');
     var $section_break_marker = "\n----------------------------------------------------------\n\n";
     var $log_reset_marker = "-------- Log File Reset --------\n";
-    
-    function __construct()
+
+    function __construct($debug_enabled)
     {
+        $this->debug_enabled = $debug_enabled;
         $this->log_folder_path = AIO_WP_SECURITY_PATH . '/logs';
     }
     
@@ -55,13 +56,9 @@ class AIOWPSecurity_Logger
         fwrite($fp, $content);
         fclose($fp);
     }
-    
+
     function log_debug($message,$level=0,$section_break=false,$file_name='')
     {
-        global $aio_wp_security;
-        $debug_config = $aio_wp_security->configs->get_value('aiowps_enable_debug');
-        $this->debug_enabled = empty($debug_config)?false:true;
-
         if (!$this->debug_enabled) return;
         $content = $this->get_debug_timestamp();//Timestamp
         $content .= $this->get_debug_status($level);//Debug status

--- a/all-in-one-wp-security/wp-security-core.php
+++ b/all-in-one-wp-security/wp-security-core.php
@@ -124,12 +124,14 @@ class AIO_WP_Security{
     function loader_operations()
     {
         add_action('plugins_loaded',array(&$this, 'plugins_loaded_handler'));//plugins loaded hook
-        $this->debug_logger = new AIOWPSecurity_Logger();
+        $this->debug_logger = new AIOWPSecurity_Logger(
+            !empty($this->configs->get_value('aiowps_enable_debug')) // ~ is debug enabled?
+        );
         if(is_admin()){
             $this->admin_init = new AIOWPSecurity_Admin_Init();
         }
     }
-    
+
     static function activate_handler()
     {
         //Only runs when the plugin activates


### PR DESCRIPTION
Some changes from closed PR #56 that I find useful.

AIOWPSecurity_Logger:
- `$level` argument check failed for `$level < 0`
- log_debug_cron method is identical to log_debug method, just operates on another file, so why not just call the latter with proper `$filename` argument
- unfinished static method removed
- `$this->debug_enabled` can be set right away in constructor instead of being set to the same value everytime debug message is added

AIOWPSecurity_Dashboard_Menu:
- properly set `$file_selected` (at the beginning of render_tab5() method, so the `selected($file_selected, ...)` works
- add missing reference to `global $aio_wp_security;`, remove unused `$error` variable