### PR TITLE
Automated DB backups filling up space

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-backup.php
+++ b/all-in-one-wp-security/classes/wp-security-backup.php
@@ -300,20 +300,21 @@ class AIOWPSecurity_Backup
                 $next_backup_time = strtotime("+".abs($backup_frequency).$interval, $last_backup_time);
                 if ($next_backup_time <= $current_time)
                 {
-                    //It's time to do a backup
-                    $result = $this->execute_backup();
-                    if ($result)
+                    // It's time to do a backup
+                    $aio_wp_security->debug_logger->log_debug_cron("DB Backup - Performing scheduled backup ...");
+                    $aio_wp_security->configs->set_value('aiowps_last_backup_time', $time_now);
+                    $aio_wp_security->configs->save_config();
+
+                    if ( $this->execute_backup() )
                     {
-                        $aio_wp_security->configs->set_value('aiowps_last_backup_time', $time_now);
-                        $aio_wp_security->configs->save_config();
                         $aio_wp_security->debug_logger->log_debug_cron("DB Backup - Scheduled backup was successfully completed.");
-                    } 
+                    }
                     else
                     {
                         $aio_wp_security->debug_logger->log_debug_cron("DB Backup - Scheduled backup operation failed!",4);
                     }
                 }
-            } 
+            }
             else
             {
                 //Set the last backup time to now so it can trigger for the next scheduled period


### PR DESCRIPTION
Based on investigation in this [support thread](https://wordpress.org/support/topic/automated-backups-filling-up-space/), I identified one possible reason for the problem. If backup procedure **dies** in the process for whatever reason (in `execute_backup` method), there are several problems:
1. incomplete backup file is created
1. no error messages are logged
1. deletion of old backup files is not performed
1. `aiowps_last_backup_time` timestamp is not updated

No 1. is not a problem by itself, but it's a problem when combined with automatic deletion of old backup files, as it is arguably better to remove newer incomplete backups than older but complete. Solution would be to somehow mark backup file as (in)complete, for example renaming it after successful dump.

No 2. makes it harder to track down any issues with backup procedure. Solution would be to run backup procedure via AJAX-ified request or similar.

No 3. is the primary cause of the problem. Solution would be to run `aiowps_delete_backup_files` method regularly (via hourly cron for example), not only after successful backup.

No 4. is not a problem by itself. I assume it can be even treated as feature: attempt to run backup process on the next occasion, if last invocation failed. However, it makes this whole problem far more pressing (like there's a 90MB backup created every hour instead of every week).

I'm going to work on fixes (I consider No 3. top priority, but No 1. should be handled as well). Let me know, if you have any thoughts on this.