### PR TITLE
Add .htaccess file to logs subdirectory

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-installer.php
+++ b/all-in-one-wp-security/classes/wp-security-installer.php
@@ -192,29 +192,6 @@ class AIOWPSecurity_Installer
 
     static function miscellaneous_tasks()
     {
-        //Create .htaccess file to protect log files in "logs" dir
-        self::create_htaccess_logs_dir();
-    }
-
-    static function create_htaccess_logs_dir()
-    {
-        global $aio_wp_security;
-        $aiowps_log_dir = AIO_WP_SECURITY_PATH . '/logs';
-        $server_type = AIOWPSecurity_Utility::get_server_type();
-        //Only create .htaccess if server is the right type
-        if ($server_type == 'apache' || $server_type == 'litespeed') {
-            $file = $aiowps_log_dir . '/.htaccess';
-            if (!file_exists($file)) {
-                //Write some rules which will stop people from viewing the log files publicly
-                $rules = '';
-                $rules .= 'order deny,allow' . PHP_EOL;
-                $rules .= 'deny from all' . PHP_EOL;
-                $write_result = file_put_contents($file, $rules);
-                if ($write_result === false) {
-                    $aio_wp_security->debug_logger->log_debug("Creation of .htaccess file in " . $aiowps_log_dir . " directory failed!", 4);
-                }
-            }
-        }
     }
 
 

--- a/all-in-one-wp-security/logs/.htaccess
+++ b/all-in-one-wp-security/logs/.htaccess
@@ -1,0 +1,7 @@
+<IfModule !mod_authz_core.c>
+	Order deny,allow
+	Deny from all
+</IfModule>
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>


### PR DESCRIPTION
Hi, since logs directory is part of the plugin codebase, why not include `.htaccess` file with proper deny directives too? Seems less error-prone than creating the file on plugin installation.

Greets,
Česlav