### PR TITLE
Always return an array from AIOWPSecurity_Utility_File::scan_dir_sort_date()

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-utility-file.php
+++ b/all-in-one-wp-security/classes/wp-security-utility-file.php
@@ -417,9 +417,9 @@ class AIOWPSecurity_Utility_File
 
     /**
      * Will return an indexed array of files sorted by last modified timestamp
-     * @param $dir
+     * @param string $dir
      * @param string $sort (ASC, DESC)
-     * @return array|bool
+     * @return array
      */
     static function scan_dir_sort_date($dir, $sort='DESC') {
         $files = array();
@@ -427,14 +427,14 @@ class AIOWPSecurity_Utility_File
             $files[$file] = filemtime($dir . '/' . $file);
         }
 
-        arsort($files);
-        $files = array_keys($files);
-        if($sort == 'ASC'){
-            $files = array_reverse($files);
+        if ($sort === 'ASC') {
+            asort($files);
         }
-        return ($files) ? $files : false;
+        else {
+            arsort($files);
+        }
+
+        return array_keys($files);
     }
-
-
 
 }


### PR DESCRIPTION
This is a minor fix - I noticed that [AIOWPSecurity_Utility_File::scan_dir_sort_date()](https://github.com/Arsenal21/all-in-one-wordpress-security/blob/master/all-in-one-wp-security/classes/wp-security-utility-file.php#L424) method is only used [here](https://github.com/Arsenal21/all-in-one-wordpress-security/blob/master/all-in-one-wp-security/classes/wp-security-backup.php#L249), but false return value is not anticipated, therefore I think the method should return an empty array instead to prevent PHP notices.

Also, it's simpler to just `asort` an array than `arsort` + `array_reverse` it.