### PR TITLE
Fix login error message for users with pending account approval.

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-user-login.php
+++ b/all-in-one-wp-security/classes/wp-security-user-login.php
@@ -143,7 +143,7 @@ class AIOWPSecurity_User_Login
         }
         if ( $user->get_error_code() === 'account_pending' ) {
             // Neither log nor block users attempting to log in before their registration is approved.
-            return;
+            return $user;
         }
         // Login failed for non-trivial reason
         $this->increment_failed_logins($username);


### PR DESCRIPTION
Hi,

I just noticed a similar issue as fixed by Davide in #68. This bug results in generic error message being displayed to user instead of "account registration approval is pending" message.

Sorry that I haven't noticed earlier.

Cheers,
Česlav