### PR TITLE
Fix typo

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-user-login.php
+++ b/all-in-one-wp-security/classes/wp-security-user-login.php
@@ -296,7 +296,7 @@ class AIOWPSecurity_User_Login
             $email_msg .= __('Username:', 'all-in-one-wp-security-and-firewall') . ' ' . $username . "\n";
             $email_msg .= __('IP Address:', 'all-in-one-wp-security-and-firewall') . ' ' . $ip . "\n\n";
             $email_msg .= __('IP Range:', 'all-in-one-wp-security-and-firewall') . ' ' . $ip_range . '.*' . "\n\n";
-            $email_msg .= __("Log into your site's WordPress administration panel to see the duration of the lockout or to unlock the user.','all-in-one-wp-security-and-firewall") . "\n";
+            $email_msg .= __("Log into your site's WordPress administration panel to see the duration of the lockout or to unlock the user.",'all-in-one-wp-security-and-firewall') . "\n";
             $site_title = get_bloginfo( 'name' );
             $from_name = empty($site_title)?'WordPress':$site_title;
             $email_header = 'From: '.$from_name.' <'.get_bloginfo('admin_email').'>' . "\r\n\\";


### PR DESCRIPTION
Reported [here](https://wordpress.org/support/topic/typo-in-lockout-notification-email/).