### PR TITLE
stop-users-enumeration: added enumeration block via REST API (wp >= 4.7)

### DIFF
--- a/all-in-one-wp-security/other-includes/wp-security-stop-users-enumeration.php
+++ b/all-in-one-wp-security/other-includes/wp-security-stop-users-enumeration.php
@@ -9,3 +9,9 @@ if (!is_admin() && isset($_SERVER['REQUEST_URI'])) {
         wp_die('Accessing author info via link is forbidden');
     }
 }
+
+if(( preg_match('/users/', $_SERVER['REQUEST_URI']) !== 0 ) || ( isset($_REQUEST['rest_route']) && ( preg_match('/users/', $_REQUEST['rest_route']) !== 0 ))){
+     if( ! is_user_logged_in() ) {
+        wp_die('Accessing author info via REST API is forbidden');      
+     }
+}


### PR DESCRIPTION
this fix a possible bypass via new wordpress's rest api inteface