### PR TITLE
WooCommerce product reviews bypassing google recapture checks

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
+++ b/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
@@ -527,7 +527,7 @@ class AIOWPSecurity_General_Init_Tasks
         }
 
         //Don't do captcha for pingback/trackback
-        if ($comment['comment_type'] != '' && $comment['comment_type'] != 'comment') {
+        if ($comment['comment_type'] != '' && $comment['comment_type'] != 'comment' && $comment['comment_type'] != 'review') {
             return $comment;
         }
         


### PR DESCRIPTION
WooCommerce adds a custom comment type called "reviews", because of this the recapture validation never happens, even thought a recapture fields appears. As most themes re-use the comment styling / process.