### PR TITLE
Contact form 7 recapture compatability issue

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-captcha.php
+++ b/all-in-one-wp-security/classes/wp-security-captcha.php
@@ -24,7 +24,7 @@ class AIOWPSecurity_Captcha
             do_action( 'bp_aiowps-captcha-answer_errors' );
         }
         $site_key = esc_html( $aio_wp_security->configs->get_value('aiowps_recaptcha_site_key') );
-        $cap_form = '<div class="g-recaptcha-wrap" style="padding:10px 0 10px 0"><div class="g-recaptcha" data-sitekey="'.$site_key.'"></div></div>';
+        $cap_form = '<div class="g-recaptcha-wrap" style="padding:10px 0 10px 0"><div id="aiowps_recaptcha_field" class="g-recaptcha" data-sitekey="'.$site_key.'"></div></div>';
         echo $cap_form;
     }
 

--- a/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
+++ b/all-in-one-wp-security/classes/wp-security-general-init-tasks.php
@@ -527,7 +527,7 @@ class AIOWPSecurity_General_Init_Tasks
         }
 
         //Don't do captcha for pingback/trackback
-        if ($comment['comment_type'] != '' && $comment['comment_type'] != 'comment') {
+        if ($comment['comment_type'] != '' && $comment['comment_type'] != 'comment' && $comment['comment_type'] != 'review') {
             return $comment;
         }
         


### PR DESCRIPTION
Contact form 7 overrides the global recapture JS include with its own, using a preset key. Contact form 7 recpture implementation uses v3, causing page comments and product reviews captures to fail to load the recapture widget incorrectly. Contact form 7 recapture loads on all front end pages.

The following pull request, if contact form 7 is used, changes the way recapture is loaded and switches to the same method used by the woo login / register recapture, as running multiple v2 and v3 scripts at the same time causes issues.

Tested and live on one of my sites.