### PR TITLE
Fix "Generate New DB Table Prefix" bug

### DIFF
--- a/all-in-one-wp-security/admin/wp-security-database-menu.php
+++ b/all-in-one-wp-security/admin/wp-security-database-menu.php
@@ -452,7 +452,9 @@ class AIOWPSecurity_Database_Menu extends AIOWPSecurity_Admin_Menu
 	foreach ($config_contents as $line_num => $line) {
             $no_ws_line = preg_replace( '/\s+/', '', $line ); //Strip white spaces
             if(strpos($no_ws_line, $prefix_match_string) !== FALSE){
-                $config_contents[$line_num] = str_replace($table_old_prefix, $table_new_prefix, $line);
+                $prefix_parts = explode("=",$config_contents[$line_num]);
+                $prefix_parts[1] = str_replace($table_old_prefix, $table_new_prefix, $prefix_parts[1]);
+                $config_contents[$line_num] = implode("=",$prefix_parts);
                 break;
             }
 	}


### PR DESCRIPTION
Problem:
If the old DB table prefix happens to also exist elsewhere in the $table_prefix line in wp-config.php then after the change is executed, all pageloads break with "Configuration Error - Your wp-config.php file has an empty database table prefix, which is not supported." because $table_prefix has been renamed.

eg: Changing the DB table prefix from "le_" to "foo_"  means `$table_prefix="le_"` becomes `$tabfoo_prefix="foo_"`

Solution:
Split line at "=" and only apply change to last part instead of whole line