### PR TITLE
Redirect on renamed login page when logged in

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-process-renamed-login-page.php
+++ b/all-in-one-wp-security/classes/wp-security-process-renamed-login-page.php
@@ -206,7 +206,16 @@ class AIOWPSecurity_Process_Renamed_Login_Page
                 || (!get_option('permalink_structure') && isset($_GET[$login_slug]))){
             if(empty($action) && is_user_logged_in()){
                 //if user is already logged in but tries to access the renamed login page, send them to the dashboard
-                AIOWPSecurity_Utility::redirect_to_url(AIOWPSEC_WP_URL."/wp-admin");
+                // or to requested redirect-page, filterd in 'login_redirect'.
+                if (isset($_REQUEST['redirect_to'])) {
+                  $redirect_to = $_REQUEST['redirect_to'];
+                  $requested_redirect_to = $redirect_to;
+                } else {
+                  $redirect_to = admin_url();
+                  $requested_redirect_to = '';
+                }
+                $redirect_to = apply_filters('login_redirect', $redirect_to, $requested_redirect_to, wp_get_current_user());
+                AIOWPSecurity_Utility::redirect_to_url($redirect_to);
             }else{
                 global $wp_version;
                 do_action('aiowps_rename_login_load');


### PR DESCRIPTION
This PR change the redirect behavior when trying to access the renamed login-page, when the user is already logged in.

This makes it possible to use links like this:
https://www.example.com/my-custom-login?redirect_to=/protected-page/
which will work regardless if the user is logged in, or not.
It also makes it possible to change the behavior with the login_redirect filter.

Before:
* All requests to the renamed login-page where directed to admin dashboard then the user where already logged in.

New behavior:
* Honer the redirect_to GET-parameter, if supplied.
* Use the login_redirect filter, which give other plugins power to customize this.

This tries to make it the same behavior as on normal login:
https://core.trac.wordpress.org/browser/tags/5.7/src/wp-login.php#L1154
