### PR TITLE
Use PHP constant for plugin management capability

### DIFF
--- a/all-in-one-wp-security/classes/wp-security-wp-loaded-tasks.php
+++ b/all-in-one-wp-security/classes/wp-security-wp-loaded-tasks.php
@@ -29,7 +29,7 @@ class AIOWPSecurity_WP_Loaded_Tasks {
                 if(!in_array($GLOBALS['pagenow'], array('wp-login.php'))){
                     self::site_lockout_tasks();
                 }
-            }else if(is_user_logged_in() && !current_user_can('manage_options') && !is_admin() && !in_array($GLOBALS['pagenow'], array('wp-login.php')) ){
+            }else if(is_user_logged_in() && !current_user_can(AIOWPSEC_MANAGEMENT_PERMISSION) && !is_admin() && !in_array($GLOBALS['pagenow'], array('wp-login.php')) ){
                 self::site_lockout_tasks();
             }
         }

--- a/all-in-one-wp-security/other-includes/wp-security-rename-login-feature-pre-5-7.php
+++ b/all-in-one-wp-security/other-includes/wp-security-rename-login-feature-pre-5-7.php
@@ -600,7 +600,7 @@ switch ( $action ) {
 			$redirect_to = admin_url();
 		}
 
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( current_user_can( AIOWPSEC_MANAGEMENT_PERMISSION ) ) {
 			$admin_email = get_option( 'admin_email' );
 		} else {
 			wp_safe_redirect( $redirect_to );
@@ -1321,7 +1321,7 @@ switch ( $action ) {
 			}
 
 			// Check if it is time to add a redirect to the admin email confirmation screen.
-			if ( is_a( $user, 'WP_User' ) && $user->exists() && $user->has_cap( 'manage_options' ) ) {
+			if ( is_a( $user, 'WP_User' ) && $user->exists() && $user->has_cap( AIOWPSEC_MANAGEMENT_PERMISSION ) ) {
 				$admin_email_lifespan = (int) get_option( 'admin_email_lifespan' );
 
 				// If `0` (or anything "falsey" as it is cast to int) is returned, the user will not be redirected

--- a/all-in-one-wp-security/other-includes/wp-security-rename-login-feature.php
+++ b/all-in-one-wp-security/other-includes/wp-security-rename-login-feature.php
@@ -458,7 +458,7 @@ switch ( $action ) {
 			$redirect_to = admin_url();
 		}
 
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( current_user_can( AIOWPSEC_MANAGEMENT_PERMISSION ) ) {
 			$admin_email = get_option( 'admin_email' );
 		} else {
 			wp_safe_redirect( $redirect_to );
@@ -1179,7 +1179,7 @@ switch ( $action ) {
 			}
 
 			// Check if it is time to add a redirect to the admin email confirmation screen.
-			if ( is_a( $user, 'WP_User' ) && $user->exists() && $user->has_cap( 'manage_options' ) ) {
+			if ( is_a( $user, 'WP_User' ) && $user->exists() && $user->has_cap( AIOWPSEC_MANAGEMENT_PERMISSION ) ) {
 				$admin_email_lifespan = (int) get_option( 'admin_email_lifespan' );
 
 				// If `0` (or anything "falsey" as it is cast to int) is returned, the user will not be redirected


### PR DESCRIPTION
Use PHP constant for plugin management capability, instead of 'manage_options'.

It seems that PHP constant `AIOWPSEC_MANAGEMENT_PERMISSION`, defined in `all-in-one-wp-security/wp-security-core.php` and defaulting to ``'manage_options'``, was not used everywhere in project's sources. This pull request tries to fix that.

Please note that I'm new to using this WordPress plugin, so any here purposed changes could be inappropriate. 